### PR TITLE
Feature: StructProperty 리플렉션 추가 및 타입 처리 개선

### DIFF
--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Templates/TypeUtilities.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Templates/TypeUtilities.h
@@ -10,7 +10,7 @@
  *          이때는 .data()와 .size()를 이용해서 직접 포인터 연산을 하거나, std::string으로 변환해서 사용하면 정상적으로 사용할 수 있습니다.
  */
 template <typename T>
-constexpr std::string_view GetTypeName(bool bIsNameOnly = true)
+constexpr std::string_view GetTypeNameString(bool bIsNameOnly = true)
 {
 #if defined(__clang__)
     constexpr std::string_view SignatureValue = __PRETTY_FUNCTION__;
@@ -84,10 +84,10 @@ constexpr std::string_view GetTypeName(bool bIsNameOnly = true)
 #elif defined(_MSC_VER)
     constexpr std::string_view FullSignature = __FUNCSIG__;
 
-    // GetTypeName< 앞부분 찾기
-    constexpr std::string_view GetTypeNameMarker = "GetTypeName<";
-    constexpr auto TypeNameStartMarkerPos = FullSignature.find(GetTypeNameMarker);
-    constexpr size_t ActualTypeNameStartPosition = TypeNameStartMarkerPos + GetTypeNameMarker.size();
+    // GetTypeNameString< 앞부분 찾기
+    constexpr std::string_view GetTypeNameStringMarker = "GetTypeNameString<";
+    constexpr auto TypeNameStartMarkerPos = FullSignature.find(GetTypeNameStringMarker);
+    constexpr size_t ActualTypeNameStartPosition = TypeNameStartMarkerPos + GetTypeNameStringMarker.size();
 
     // >( 파라미터 시작 전의 꺾쇠 닫기
     // 또는 마지막 > 를 찾고, 그게 파라미터 리스트의 닫는 괄호인지 확인
@@ -137,7 +137,7 @@ constexpr std::string_view GetTypeName(bool bIsNameOnly = true)
         // 대체 로직: 마지막 '>'를 찾는다.
         // 이는 중첩 템플릿 (예: MyType<OtherType<int>>)에서 내부 템플릿의 '>'를 잡을 위험이 있음.
         // __FUNCSIG__ 구조에 대한 강한 가정이 필요함.
-        // 일반적으로 GetTypeName<...TYPE...>(bool...) 형태일 것이므로,
+        // 일반적으로 GetTypeNameString<...TYPE...>(bool...) 형태일 것이므로,
         // 마지막 '>'가 타입의 끝일 가능성이 높습니다.
         auto TempEndPos = FullSignature.rfind('>');
         // 그 '>'가 함수 파라미터 '(' 앞에 있는지 확인
@@ -339,14 +339,14 @@ constexpr std::string_view GetTypeName(bool bIsNameOnly = true)
 #endif
 }
 
-#pragma region GetTypeName Test Cases
+#pragma region GetTypeNameString Test Cases
 #if false  // NOLINT(readability-avoid-unconditional-preprocessor-if)
 enum class MyEnum {};
 inline void RunTypeNameTests()
 {
     std::cout << std::boolalpha; // bool 값을 "true" 또는 "false"로 출력
 
-    std::cout << "--- GetTypeName Test Cases ---" << std::endl;
+    std::cout << "--- GetTypeNameString Test Cases ---" << std::endl;
 
     // 헬퍼 함수: 테스트 결과를 출력
     auto PrintTestResult = [](const char* testName, std::string_view expected, std::string_view actualTrue, std::string_view actualFalse)
@@ -366,7 +366,7 @@ inline void RunTypeNameTests()
     // bIsNameOnly = true 시 기대 결과: "MyEnum"
     {
         using TestType1 = MyEnum*********; // 9개의 '*'
-        PrintTestResult("MyEnum*********", "MyEnum", GetTypeName<TestType1>(true), GetTypeName<TestType1>(false));
+        PrintTestResult("MyEnum*********", "MyEnum", GetTypeNameString<TestType1>(true), GetTypeNameString<TestType1>(false));
     }
 
     // 케이스 2: <volatile const volatile const MyEnum ** * ** const volatile>
@@ -376,92 +376,92 @@ inline void RunTypeNameTests()
     // bIsNameOnly = true 시 기대 결과: "MyEnum"
     {
         using TestType2 = const volatile MyEnum***** const volatile;
-        PrintTestResult("const volatile MyEnum***** const volatile", "MyEnum", GetTypeName<TestType2>(true), GetTypeName<TestType2>(false));
+        PrintTestResult("const volatile MyEnum***** const volatile", "MyEnum", GetTypeNameString<TestType2>(true), GetTypeNameString<TestType2>(false));
     }
 
     // === 추가적인 일반 테스트 케이스 ===
 
-    PrintTestResult("int", "int", GetTypeName<int>(true), GetTypeName<int>(false));
-    PrintTestResult("const int", "int", GetTypeName<const int>(true), GetTypeName<const int>(false));
-    PrintTestResult("volatile int", "int", GetTypeName<volatile int>(true), GetTypeName<volatile int>(false));
-    PrintTestResult("const volatile int", "int", GetTypeName<const volatile int>(true), GetTypeName<const volatile int>(false));
+    PrintTestResult("int", "int", GetTypeNameString<int>(true), GetTypeNameString<int>(false));
+    PrintTestResult("const int", "int", GetTypeNameString<const int>(true), GetTypeNameString<const int>(false));
+    PrintTestResult("volatile int", "int", GetTypeNameString<volatile int>(true), GetTypeNameString<volatile int>(false));
+    PrintTestResult("const volatile int", "int", GetTypeNameString<const volatile int>(true), GetTypeNameString<const volatile int>(false));
 
-    PrintTestResult("int*", "int", GetTypeName<int*>(true), GetTypeName<int*>(false));
-    PrintTestResult("const int*", "int", GetTypeName<const int*>(true), GetTypeName<const int*>(false)); // int가 const, 포인터는 아님
-    PrintTestResult("int* const", "int", GetTypeName<int* const>(true), GetTypeName<int* const>(false)); // 포인터가 const
-    PrintTestResult("int* volatile", "int", GetTypeName<int* volatile>(true), GetTypeName<int* volatile>(false));
-    PrintTestResult("int* const volatile", "int", GetTypeName<int* const volatile>(true), GetTypeName<int* const volatile>(false));
-    PrintTestResult("const int* const", "int", GetTypeName<const int* const>(true), GetTypeName<const int* const>(false));
+    PrintTestResult("int*", "int", GetTypeNameString<int*>(true), GetTypeNameString<int*>(false));
+    PrintTestResult("const int*", "int", GetTypeNameString<const int*>(true), GetTypeNameString<const int*>(false)); // int가 const, 포인터는 아님
+    PrintTestResult("int* const", "int", GetTypeNameString<int* const>(true), GetTypeNameString<int* const>(false)); // 포인터가 const
+    PrintTestResult("int* volatile", "int", GetTypeNameString<int* volatile>(true), GetTypeNameString<int* volatile>(false));
+    PrintTestResult("int* const volatile", "int", GetTypeNameString<int* const volatile>(true), GetTypeNameString<int* const volatile>(false));
+    PrintTestResult("const int* const", "int", GetTypeNameString<const int* const>(true), GetTypeNameString<const int* const>(false));
 
-    PrintTestResult("int&", "int", GetTypeName<int&>(true), GetTypeName<int&>(false));
-    PrintTestResult("const int&", "int", GetTypeName<const int&>(true), GetTypeName<const int&>(false));
-    PrintTestResult("volatile int&", "int", GetTypeName<volatile int&>(true), GetTypeName<volatile int&>(false));
-    PrintTestResult("int&&", "int", GetTypeName<int&&>(true), GetTypeName<int&&>(false));
+    PrintTestResult("int&", "int", GetTypeNameString<int&>(true), GetTypeNameString<int&>(false));
+    PrintTestResult("const int&", "int", GetTypeNameString<const int&>(true), GetTypeNameString<const int&>(false));
+    PrintTestResult("volatile int&", "int", GetTypeNameString<volatile int&>(true), GetTypeNameString<volatile int&>(false));
+    PrintTestResult("int&&", "int", GetTypeNameString<int&&>(true), GetTypeNameString<int&&>(false));
 
     // 사용자 정의 타입
     struct AnotherStruct
     {
     };
-    PrintTestResult("AnotherStruct", "AnotherStruct", GetTypeName<AnotherStruct>(true), GetTypeName<AnotherStruct>(false));
-    PrintTestResult("const AnotherStruct&", "AnotherStruct", GetTypeName<const AnotherStruct&>(true), GetTypeName<const AnotherStruct&>(false));
+    PrintTestResult("AnotherStruct", "AnotherStruct", GetTypeNameString<AnotherStruct>(true), GetTypeNameString<AnotherStruct>(false));
+    PrintTestResult("const AnotherStruct&", "AnotherStruct", GetTypeNameString<const AnotherStruct&>(true), GetTypeNameString<const AnotherStruct&>(false));
     PrintTestResult(
-        "volatile AnotherStruct*", "AnotherStruct", GetTypeName<volatile AnotherStruct*>(true), GetTypeName<volatile AnotherStruct*>(false)
+        "volatile AnotherStruct*", "AnotherStruct", GetTypeNameString<volatile AnotherStruct*>(true), GetTypeNameString<volatile AnotherStruct*>(false)
     );
 
     // 다중 포인터 및 cv 한정자
     PrintTestResult(
-        "MyEnum const*volatile**const*", "MyEnum", GetTypeName<MyEnum const*volatile**const*>(true), GetTypeName<MyEnum const*volatile**const*>(false)
+        "MyEnum const*volatile**const*", "MyEnum", GetTypeNameString<MyEnum const*volatile**const*>(true), GetTypeNameString<MyEnum const*volatile**const*>(false)
     );
     PrintTestResult(
-        "const volatile MyEnum * const * volatile *", "MyEnum", GetTypeName<const volatile MyEnum* const * volatile *>(true),
-        GetTypeName<const volatile MyEnum* const * volatile *>(false)
+        "const volatile MyEnum * const * volatile *", "MyEnum", GetTypeNameString<const volatile MyEnum* const * volatile *>(true),
+        GetTypeNameString<const volatile MyEnum* const * volatile *>(false)
     );
 
 
     // 사용자가 언급한 "MyEnum*****volatile" 결과가 나오는 경우를 재현하기 위한 입력 타입 추정
-    // 만약 GetTypeName< TYPE >() 의 결과가 "MyEnum*****volatile" 이었다면,
+    // 만약 GetTypeNameString< TYPE >() 의 결과가 "MyEnum*****volatile" 이었다면,
     // TYPE 은 예를 들어 (MyEnum*****)volatile 또는 MyEnum volatile ***** 와 유사한 구조일 수 있습니다.
     // 또는 (MyEnum***** const) volatile 같은 형태.
     // 아래는 그러한 타입에 대한 테스트입니다.
     {
         using FiveStarMyEnum = MyEnum*****;
         using TestTypeUserIssue1 = FiveStarMyEnum volatile; // (MyEnum*****) volatile
-        PrintTestResult("(MyEnum*****) volatile", "MyEnum", GetTypeName<TestTypeUserIssue1>(true), GetTypeName<TestTypeUserIssue1>(false));
+        PrintTestResult("(MyEnum*****) volatile", "MyEnum", GetTypeNameString<TestTypeUserIssue1>(true), GetTypeNameString<TestTypeUserIssue1>(false));
     }
     {
         using TestTypeUserIssue2 = MyEnum volatile*****;
-        PrintTestResult("MyEnum volatile *****", "MyEnum", GetTypeName<TestTypeUserIssue2>(true), GetTypeName<TestTypeUserIssue2>(false));
+        PrintTestResult("MyEnum volatile *****", "MyEnum", GetTypeNameString<TestTypeUserIssue2>(true), GetTypeNameString<TestTypeUserIssue2>(false));
     }
     {
         // 사용자의 예시: volatile const volatile const MyEnum ***** const volatile
         // 이것은 위에서 TestType2로 이미 테스트되었고, 기대값은 "MyEnum" 입니다.
-        // 만약 이것이 "MyEnum*****volatile"로 나온다면, GetTypeName 내부 로직 (특히 MSVC 파서)에 문제가 있는 것입니다.
+        // 만약 이것이 "MyEnum*****volatile"로 나온다면, GetTypeNameString 내부 로직 (특히 MSVC 파서)에 문제가 있는 것입니다.
         // 이 테스트는 해당 케이스가 "MyEnum"을 반환하는지 재확인합니다.
         using TypeFromUserExample = volatile const volatile const MyEnum***** const volatile;
         PrintTestResult(
-            "FROM USER: volatile const volatile const MyEnum ***** const volatile", "MyEnum", GetTypeName<TypeFromUserExample>(true),
-            GetTypeName<TypeFromUserExample>(false)
+            "FROM USER: volatile const volatile const MyEnum ***** const volatile", "MyEnum", GetTypeNameString<TypeFromUserExample>(true),
+            GetTypeNameString<TypeFromUserExample>(false)
         );
     }
 
 
     // 배열 타입 (현재 로직은 배열의 '[]'를 제거하지 않음)
     // MSVC에서 `const char[N]`은 `char const [N]`으로 나올 수 있음.
-    PrintTestResult("char[10]", "char[10]", GetTypeName<char[10]>(true), GetTypeName<char[10]>(false));
+    PrintTestResult("char[10]", "char[10]", GetTypeNameString<char[10]>(true), GetTypeNameString<char[10]>(false));
     // 현재 로직으로는 'const char[N]' 또는 'char const [N]'에서 'const'만 제거하기는 어려움.
     // MSVC `__FUNCSIG__`는 "char const [5]" 형태를 띌 수 있습니다.
     // 현재 IsAlnumChar 기반 제거 로직은 "const"가 다른 식별자와 붙어있지 않은 경우에만 작동합니다.
     // "char const [5]"의 "const"는 "char " 뒤, " [5]" 앞에 있어, "const " 또는 " const" 패턴으로 제거될 수 있지만,
     // 공백 없는 "const" 제거 로직은 앞뒤가 IsAlnumChar가 아닐 때 작동하므로, "char const [5]"의 "const"를 제거할 수도 있습니다.
     // 만약 "char const [5]" -> "char [5]" 로 만든다면, 현재 코드는 그렇게 동작할 가능성이 있습니다.
-    PrintTestResult("const char[10]", "char[10]", GetTypeName<const char[10]>(true), GetTypeName<const char[10]>(false));
+    PrintTestResult("const char[10]", "char[10]", GetTypeNameString<const char[10]>(true), GetTypeNameString<const char[10]>(false));
 
 
     // 함수 포인터 (단순화가 어려움, bIsNameOnly=false의 출력이 더 유용)
     using FunctionPtrType = void(*)(int, double);
     std::cout << "\nTest: void(*)(int, double)" << std::endl;
-    std::cout << "  bIsNameOnly = true: Actual: \"" << GetTypeName<FunctionPtrType>(true) << "\"" << std::endl;
-    std::cout << "  bIsNameOnly = false: Actual: \"" << GetTypeName<FunctionPtrType>(false) << "\"" << std::endl;
+    std::cout << "  bIsNameOnly = true: Actual: \"" << GetTypeNameString<FunctionPtrType>(true) << "\"" << std::endl;
+    std::cout << "  bIsNameOnly = false: Actual: \"" << GetTypeNameString<FunctionPtrType>(false) << "\"" << std::endl;
 
 
     std::cout << "\n--- All Tests Completed ---" << std::endl;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Class.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Class.cpp
@@ -13,22 +13,13 @@ UClass::UClass(
     UClass* InSuperClass,
     ClassConstructorType InCTOR
 )
-    : ClassCTOR(InCTOR)
-    , ClassSize(InClassSize)
-    , ClassAlignment(InAlignment)
-    , SuperClass(InSuperClass)
+    : UStruct(InClassName, InClassSize, InAlignment, InSuperClass)
+    , ClassCTOR(InCTOR)
 {
-    NamePrivate = InClassName;
 }
 
 UClass::~UClass()
 {
-    for (const FProperty* Prop : Properties)
-    {
-        delete Prop;
-    }
-    Properties.Empty();
-
     delete ClassDefaultObject;
     ClassDefaultObject = nullptr;
 }
@@ -48,35 +39,9 @@ UClass* UClass::FindClass(const FName& ClassName)
     return nullptr;
 }
 
-void UClass::ResolvePendingProperties()
-{
-    for (FProperty* Prop : GetUnresolvedProperties())
-    {
-        Prop->Resolve();
-    }
-    GetUnresolvedProperties().Empty();
-}
-
-TArray<FProperty*>& UClass::GetUnresolvedProperties()
-{
-    static TArray<FProperty*> UnresolvedProperties;
-    return UnresolvedProperties;
-}
-
 bool UClass::IsChildOf(const UClass* SomeBase) const
 {
-    assert(this);
-    if (!SomeBase) { return false; }
-
-    // Super의 Super를 반복하면서 
-    for (const UClass* TempClass = this; TempClass; TempClass=TempClass->GetSuperClass())
-    {
-        if (TempClass == SomeBase)
-        {
-            return true;
-        }
-    }
-    return false;
+    return Super::IsChildOf(SomeBase);
 }
 
 UObject* UClass::GetDefaultObject() const
@@ -86,46 +51,6 @@ UObject* UClass::GetDefaultObject() const
         const_cast<UClass*>(this)->CreateDefaultObject();
     }
     return ClassDefaultObject;
-}
-
-void UClass::RegisterProperty(FProperty* Prop)
-{
-    /* 왠지 모르겠지만 TArray(std::vector)를 사용하면 Debug모드에서 Iterator검사를 하게 되는데,
-     * 이때 검사할 때 잘못된 Iterator를 역참조해서 프로그램이 터짐, 근데 또 Release에서는 검사를 안하니 잘 동작함.
-     * 
-     * 이유를 찾아보니 static 변수 초기화 순서 문제일 가능성이 있음.
-     * 컴파일러마다 다를 수 있지만, UnresolvedProperties가 다른 static 변수보다 늦게 초기화가 되면,
-     * 이터레이터 추적을 위한 내부 프록시 객체(_Mypair._Myval2._Myproxy)가 제대로 설정되지 않은 상태일 수 있기 때문에 문제가 생길 수 있음
-     * TQueue도 마찬가지, TQueue는 Iterator검사는 안하지만, UnresolvedProperties가 가장 늦게 초기화 되는경우, 기존에 데이터가 없어지는 문제가 생겼음
-     */
-    switch (Prop->Type)  // NOLINT(clang-diagnostic-switch-enum)
-    {
-    case EPropertyType::UnresolvedPointer:
-    {
-        GetUnresolvedProperties().Add(Prop);
-        break;
-    }
-    default:
-        break;
-    }
-
-    Properties.Add(Prop);
-}
-
-void UClass::SerializeBin(FArchive& Ar, void* Data)
-{
-    // 상속받은 클래스의 프로퍼티들도 직렬화
-    if (SuperClass)
-    {
-        SuperClass->SerializeBin(Ar, Data);
-    }
-
-    // 이 클래스의 프로퍼티들 직렬화
-    for (const FProperty* Prop : Properties)
-    {
-        void* PropData = static_cast<uint8*>(Data) + Prop->Offset;
-        Ar.Serialize(PropData, Prop->Size);
-    }
 }
 
 UObject* UClass::CreateDefaultObject()

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Object.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Object.h
@@ -27,7 +27,8 @@ public:
 private:
     friend class FObjectFactory;
     friend class FSceneMgr;
-    friend class UClass;
+    friend class UClass; // TODO: 제거
+    friend class UStruct;
 
     uint32 UUID;
     uint32 InternalIndex; // Index of GUObjectArray

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Object.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Object.h
@@ -27,8 +27,8 @@ public:
 private:
     friend class FObjectFactory;
     friend class FSceneMgr;
-    friend class UClass; // TODO: 제거
     friend class UStruct;
+    friend class UClass;
 
     uint32 UUID;
     uint32 InternalIndex; // Index of GUObjectArray

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ObjectFactory.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ObjectFactory.h
@@ -26,7 +26,7 @@ public:
 
         GUObjectArray.AddObject(Obj);
 
-        UE_LOGFMT(ELogLevel::Display, "Created Object: {}, Size: {}", Obj->GetName(), InClass->GetClassSize());
+        UE_LOGFMT(ELogLevel::Display, "Created Object: {}, Size: {}", Obj->GetName(), InClass->GetPropertiesSize());
 
         return Obj;
     }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ObjectFactory.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ObjectFactory.h
@@ -26,7 +26,7 @@ public:
 
         GUObjectArray.AddObject(Obj);
 
-        UE_LOGFMT(ELogLevel::Display, "Created Object: {}, Size: {}", Obj->GetName(), InClass->GetPropertiesSize());
+        UE_LOGFMT(ELogLevel::Display, "Created Object: {}, Size: {}", Obj->GetName(), InClass->GetStructSize());
 
         return Obj;
     }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ObjectMacros.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ObjectMacros.h
@@ -74,7 +74,7 @@ public: \
         { \
             constexpr int64 Offset = offsetof(ThisClass, InVarName); \
             constexpr EPropertyFlags Flags = InFlags; \
-            ThisClass::StaticClass()->RegisterProperty( \
+            ThisClass::StaticClass()->AddProperty( \
                 PropertyFactory::Private::MakeProperty<InType, Flags>(ThisClass::StaticClass(), #InVarName, Offset) \
             ); \
         } \

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ObjectMacros.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ObjectMacros.h
@@ -1,5 +1,6 @@
 // ReSharper disable CppClangTidyBugproneMacroParentheses
 // ReSharper disable CppClangTidyClangDiagnosticPedantic
+// ReSharper disable CppClangTidyClangDiagnosticReservedMacroIdentifier
 #pragma once
 #include "Class.h"
 #include "UObjectHash.h"

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ObjectMacros.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ObjectMacros.h
@@ -3,7 +3,6 @@
 #pragma once
 #include "Class.h"
 #include "UObjectHash.h"
-#include "Templates/TypeUtilities.h"
 
 // name을 문자열화 해주는 매크로
 #define INLINE_STRINGIFY(name) #name

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ObjectMacros.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ObjectMacros.h
@@ -69,13 +69,13 @@ public: \
 // ---------- DECLARE_STRUCT 관련 매크로 ----------
 #define DECLARE_COMMON_STRUCT_BODY(TStruct, TSuperStruct) \
 private: \
-    inline static struct Z_TStruct##_StructRegistrar_PRIVATE \
+    inline static struct Z_##TStruct##_StructRegistrar_PRIVATE \
     { \
-        Z_TStruct##_StructRegistrar_PRIVATE() \
+        Z_##TStruct##_StructRegistrar_PRIVATE() \
         { \
             UScriptStruct::GetScriptStructMap().Add(FName(INLINE_STRINGIFY(TStruct)), TStruct::StaticStruct()); \
         } \
-    } Z_TStruct##_StructRegistrar_Instance_PRIVATE{}; \
+    } Z_##TStruct##_StructRegistrar_Instance_PRIVATE{}; \
 public: \
     using Super = TSuperStruct; \
     using ThisClass = TStruct;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ObjectMacros.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ObjectMacros.h
@@ -5,12 +5,15 @@
 #include "Class.h"
 #include "UObjectHash.h"
 
+// MSVC에서 매크로 확장 문제를 해결하기 위한 매크로
+#define EXPAND_MACRO(x) x
+
 // name을 문자열화 해주는 매크로
 #define INLINE_STRINGIFY(name) #name
 
 
 // 공통 클래스 정의 부분
-#define __DECLARE_COMMON_CLASS_BODY__(TClass, TSuperClass) \
+#define DECLARE_COMMON_CLASS_BODY(TClass, TSuperClass) \
 private: \
     TClass(const TClass&) = delete; \
     TClass& operator=(const TClass&) = delete; \
@@ -31,7 +34,7 @@ public: \
 
 // RTTI를 위한 클래스 매크로
 #define DECLARE_CLASS(TClass, TSuperClass) \
-    __DECLARE_COMMON_CLASS_BODY__(TClass, TSuperClass) \
+    DECLARE_COMMON_CLASS_BODY(TClass, TSuperClass) \
     static UClass* StaticClass() { \
         static UClass ClassInfo{ \
             #TClass, \
@@ -49,7 +52,7 @@ public: \
 
 // RTTI를 위한 추상 클래스 매크로
 #define DECLARE_ABSTRACT_CLASS(TClass, TSuperClass) \
-    __DECLARE_COMMON_CLASS_BODY__(TClass, TSuperClass) \
+    DECLARE_COMMON_CLASS_BODY(TClass, TSuperClass) \
     static UClass* StaticClass() { \
         static UClass ClassInfo{ \
             #TClass, \
@@ -83,8 +86,7 @@ public: \
 #define UPROPERTY_DEFAULT(InType, InVarName, ...) \
     UPROPERTY_WITH_FLAGS(EPropertyFlags::PropertyNone, InType, InVarName, __VA_ARGS__)
 
-#define EXPAND_PROPERTY_MACRO(x) x
-#define GET_OVERLOADED_PROPERTY_MACRO(_1, _2, _3, _4, NAME, ...) NAME
+#define GET_OVERLOADED_PROPERTY_MACRO(_1, _2, _3, _4, MACRO, ...) MACRO
 
 /**
  * UClass에 Property를 등록합니다.
@@ -101,4 +103,4 @@ public: \
  * UPROPERTY(EPropertyFlags::EditAnywhere, int, Value, = 10) // Flag를 지정하면 기본값은 필수
  */
 #define UPROPERTY(...) \
-    EXPAND_PROPERTY_MACRO(GET_OVERLOADED_PROPERTY_MACRO(__VA_ARGS__, UPROPERTY_WITH_FLAGS, UPROPERTY_DEFAULT, UPROPERTY_DEFAULT)(__VA_ARGS__))
+    EXPAND_MACRO(GET_OVERLOADED_PROPERTY_MACRO(__VA_ARGS__, UPROPERTY_WITH_FLAGS, UPROPERTY_DEFAULT, UPROPERTY_DEFAULT)(__VA_ARGS__))

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ObjectMacros.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ObjectMacros.h
@@ -77,8 +77,9 @@ public: \
         { \
             constexpr int64 Offset = offsetof(ThisClass, InVarName); \
             constexpr EPropertyFlags Flags = InFlags; \
-            ThisClass::StaticClass()->AddProperty( \
-                PropertyFactory::Private::MakeProperty<InType, Flags>(ThisClass::StaticClass(), #InVarName, Offset) \
+            UStruct* StructPtr = GetStructHelper<ThisClass>(); \
+            StructPtr->AddProperty( \
+                PropertyFactory::Private::MakeProperty<InType, Flags>(StructPtr, #InVarName, Offset) \
             ); \
         } \
     } InVarName##_PropRegistrar_PRIVATE{};

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ObjectMacros.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ObjectMacros.h
@@ -67,7 +67,7 @@ public: \
 
 
 // ---------- DECLARE_STRUCT 관련 매크로 ----------
-#define DECLARE_COMMON_STRUCT_BODY(TStruct) \
+#define DECLARE_COMMON_STRUCT_BODY(TStruct, TSuperStruct) \
 private: \
     inline static struct Z_TStruct##_StructRegistrar_PRIVATE \
     { \
@@ -77,11 +77,11 @@ private: \
         } \
     } Z_TStruct##_StructRegistrar_Instance_PRIVATE{}; \
 public: \
-    using Super = TStruct; \
+    using Super = TSuperStruct; \
     using ThisClass = TStruct;
 
 #define DECLARE_STRUCT_WITH_SUPER(TStruct, TSuperStruct) \
-    DECLARE_COMMON_STRUCT_BODY(TStruct) \
+    DECLARE_COMMON_STRUCT_BODY(TStruct, TSuperStruct) \
     static UScriptStruct* StaticStruct() \
     { \
         static UScriptStruct StructInfo{ \
@@ -94,7 +94,7 @@ public: \
     }
 
 #define DECLARE_STRUCT_NO_SUPER(TStruct) \
-    DECLARE_COMMON_STRUCT_BODY(TStruct) \
+    DECLARE_COMMON_STRUCT_BODY(TStruct, TStruct) \
     static UScriptStruct* StaticStruct() \
     { \
         static UScriptStruct StructInfo{ \

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
@@ -1029,6 +1029,8 @@ struct FStructProperty : public FProperty
         : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Struct, InSize, InOffset, InFlags)
     {
     }
+
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override;
 };
 
 struct FUnresolvedPtrProperty : public FProperty

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
@@ -1142,7 +1142,13 @@ FProperty* MakeProperty(
     }
     else if constexpr (TypeEnum == EPropertyType::StructPointer)
     {
-        // TODO: Implements This
+        using PointerType = std::remove_cvref_t<std::remove_pointer_t<T>>;
+        FUnresolvedPtrProperty* Property = new FUnresolvedPtrProperty{InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags};
+
+        Property->Type = EPropertyType::Struct;
+        Property->TypeSpecificData = PointerType::StaticStruct();
+        Property->ResolvedProperty = new FStructProperty{InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags};
+        return Property;
     }
     else if constexpr (TypeEnum == EPropertyType::SubclassOf)
     {
@@ -1162,8 +1168,6 @@ FProperty* MakeProperty(
     {
         using PointerType = std::remove_cvref_t<std::remove_pointer_t<T>>;
         FProperty* Property = new FObjectProperty { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags };
-
-        // Property륻 등록하는 시점에서는 아직 모든 UClass가 초기화되지 않았으므로, UEngine::Init()때 Property의 TypeName을 바탕으로 ClassMap에서 가져오기
         Property->TypeSpecificData = PointerType::StaticClass();
         return Property;
     }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
@@ -1135,26 +1135,31 @@ FProperty* MakeProperty(
         return Property;
     }
 
-    else if constexpr (TypeEnum == EPropertyType::Enum)        { return new TEnumProperty<T>     { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
+    else if constexpr (TypeEnum == EPropertyType::Enum)
+    {
+        return new TEnumProperty<T>{ InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags };
+    }
     else if constexpr (TypeEnum == EPropertyType::Struct)
     {
-        return new FStructProperty { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags };
+        FProperty* Property = new FStructProperty{ InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags };
+        Property->TypeSpecificData = T::StaticStruct();
+        return Property;
     }
     else if constexpr (TypeEnum == EPropertyType::StructPointer)
     {
         using PointerType = std::remove_cvref_t<std::remove_pointer_t<T>>;
-        FUnresolvedPtrProperty* Property = new FUnresolvedPtrProperty{InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags};
+        FUnresolvedPtrProperty* Property = new FUnresolvedPtrProperty{ InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags };
 
         Property->Type = EPropertyType::Struct;
         Property->TypeSpecificData = PointerType::StaticStruct();
-        Property->ResolvedProperty = new FStructProperty{InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags};
+        Property->ResolvedProperty = new FStructProperty{ InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags };
         return Property;
     }
     else if constexpr (TypeEnum == EPropertyType::SubclassOf)
     {
         if constexpr (std::derived_from<typename T::ElementType, UObject>)
         {
-            FProperty* Property = new FSubclassOfProperty { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags };
+            FProperty* Property = new FSubclassOfProperty{ InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags };
             Property->TypeSpecificData = T::ElementType::StaticClass();
             return Property;
         }
@@ -1167,14 +1172,14 @@ FProperty* MakeProperty(
     else if constexpr (TypeEnum == EPropertyType::Object)
     {
         using PointerType = std::remove_cvref_t<std::remove_pointer_t<T>>;
-        FProperty* Property = new FObjectProperty { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags };
+        FProperty* Property = new FObjectProperty{ InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags };
         Property->TypeSpecificData = PointerType::StaticClass();
         return Property;
     }
     else if constexpr (TypeEnum == EPropertyType::UnresolvedPointer)
     {
         constexpr std::string_view TypeName = GetTypeNameString<T>();
-        FProperty* Property = new FUnresolvedPtrProperty { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags };
+        FProperty* Property = new FUnresolvedPtrProperty{ InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags };
         Property->TypeSpecificData = FName(TypeName.data(), TypeName.size());
         return Property;
     }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
@@ -26,8 +26,8 @@ struct FProperty
         UStruct* InOwnerStruct,
         const char* InPropertyName,
         EPropertyType InType,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : OwnerStruct(InOwnerStruct)
@@ -159,8 +159,8 @@ struct FNumericProperty : public FProperty
         UStruct* InOwnerStruct,
         const char* InPropertyName,
         EPropertyType InType,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FProperty(InOwnerStruct, InPropertyName, InType, InSize, InOffset, InFlags)
@@ -175,8 +175,8 @@ struct FInt8Property : public FNumericProperty
     FInt8Property(
         UStruct* InOwnerStruct,
         const char* InPropertyName,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::Int8, InSize, InOffset, InFlags)
@@ -191,8 +191,8 @@ struct FInt16Property : public FNumericProperty
     FInt16Property(
         UStruct* InOwnerStruct,
         const char* InPropertyName,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::Int16, InSize, InOffset, InFlags)
@@ -207,8 +207,8 @@ struct FInt32Property : public FNumericProperty
     FInt32Property(
         UStruct* InOwnerStruct,
         const char* InPropertyName,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::Int32, InSize, InOffset, InFlags)
@@ -223,8 +223,8 @@ struct FInt64Property : public FNumericProperty
     FInt64Property(
         UStruct* InOwnerStruct,
         const char* InPropertyName,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::Int64, InSize, InOffset, InFlags)
@@ -239,8 +239,8 @@ struct FUInt8Property : public FNumericProperty
     FUInt8Property(
         UStruct* InOwnerStruct,
         const char* InPropertyName,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::UInt8, InSize, InOffset, InFlags)
@@ -255,8 +255,8 @@ struct FUInt16Property : public FNumericProperty
     FUInt16Property(
         UStruct* InOwnerStruct,
         const char* InPropertyName,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::UInt16, InSize, InOffset, InFlags)
@@ -271,8 +271,8 @@ struct FUInt32Property : public FNumericProperty
     FUInt32Property(
         UStruct* InOwnerStruct,
         const char* InPropertyName,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::UInt32, InSize, InOffset, InFlags)
@@ -287,8 +287,8 @@ struct FUInt64Property : public FNumericProperty
     FUInt64Property(
         UStruct* InOwnerStruct,
         const char* InPropertyName,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::UInt64, InSize, InOffset, InFlags)
@@ -303,8 +303,8 @@ struct FFloatProperty : public FNumericProperty
     FFloatProperty(
         UStruct* InOwnerStruct,
         const char* InPropertyName,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::Float, InSize, InOffset, InFlags)
@@ -319,8 +319,8 @@ struct FDoubleProperty : public FNumericProperty
     FDoubleProperty(
         UStruct* InOwnerStruct,
         const char* InPropertyName,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::Double, InSize, InOffset, InFlags)
@@ -335,8 +335,8 @@ struct FBoolProperty : public FProperty
     FBoolProperty(
         UStruct* InOwnerStruct,
         const char* InPropertyName,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Bool, InSize, InOffset, InFlags)
@@ -352,8 +352,8 @@ struct FStrProperty : public FProperty
     FStrProperty(
         UStruct* InOwnerStruct,
         const char* InPropertyName,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FProperty(InOwnerStruct, InPropertyName, EPropertyType::String, InSize, InOffset, InFlags)
@@ -369,8 +369,8 @@ struct FNameProperty : public FProperty
     FNameProperty(
         UStruct* InOwnerStruct,
         const char* InPropertyName,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Name, InSize, InOffset, InFlags)
@@ -384,8 +384,8 @@ struct FVector2DProperty : public FProperty
     FVector2DProperty(
         UStruct* InOwnerStruct,
         const char* InPropertyName,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Vector2D, InSize, InOffset, InFlags)
@@ -401,8 +401,8 @@ struct FVectorProperty : public FProperty
     FVectorProperty(
         UStruct* InOwnerStruct,
         const char* InPropertyName,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Vector, InSize, InOffset, InFlags)
@@ -418,8 +418,8 @@ struct FVector4Property : public FProperty
     FVector4Property(
         UStruct* InOwnerStruct,
         const char* InPropertyName,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Vector4, InSize, InOffset, InFlags)
@@ -435,8 +435,8 @@ struct FRotatorProperty : public FProperty
     FRotatorProperty(
         UStruct* InOwnerStruct,
         const char* InPropertyName,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Rotator, InSize, InOffset, InFlags)
@@ -452,8 +452,8 @@ struct FQuatProperty : public FProperty
     FQuatProperty(
         UStruct* InOwnerStruct,
         const char* InPropertyName,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Quat, InSize, InOffset, InFlags)
@@ -469,8 +469,8 @@ struct FTransformProperty : public FProperty
     FTransformProperty(
         UStruct* InOwnerStruct,
         const char* InPropertyName,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Transform, InSize, InOffset, InFlags)
@@ -485,8 +485,8 @@ struct FMatrixProperty : public FProperty
     FMatrixProperty(
         UStruct* InOwnerStruct,
         const char* InPropertyName,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Matrix, InSize, InOffset, InFlags)
@@ -501,8 +501,8 @@ struct FColorProperty : public FProperty
     FColorProperty(
         UStruct* InOwnerStruct,
         const char* InPropertyName,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Color, InSize, InOffset, InFlags)
@@ -518,8 +518,8 @@ struct FLinearColorProperty : public FProperty
     FLinearColorProperty(
         UStruct* InOwnerStruct,
         const char* InPropertyName,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FProperty(InOwnerStruct, InPropertyName, EPropertyType::LinearColor, InSize, InOffset, InFlags)
@@ -540,8 +540,8 @@ struct TArrayProperty : public FProperty
     TArrayProperty(
         UStruct* InOwnerStruct,
         const char* InPropertyName,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Array, InSize, InOffset, InFlags)
@@ -660,8 +660,8 @@ struct TMapProperty : public FProperty
     TMapProperty(
         UStruct* InOwnerStruct,
         const char* InPropertyName,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Map, InSize, InOffset, InFlags)
@@ -811,8 +811,8 @@ struct TSetProperty : public FProperty
     TSetProperty(
         UStruct* InOwnerStruct,
         const char* InPropertyName,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Set, InSize, InOffset, InFlags)
@@ -935,8 +935,8 @@ struct TEnumProperty : public FProperty
     TEnumProperty(
         UStruct* InOwnerStruct,
         const char* InPropertyName,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Enum, InSize, InOffset, InFlags)
@@ -989,8 +989,8 @@ struct FSubclassOfProperty : public FProperty
     FSubclassOfProperty(
         UStruct* InOwnerStruct,
         const char* InPropertyName,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FProperty(InOwnerStruct, InPropertyName, EPropertyType::SubclassOf, InSize, InOffset, InFlags)
@@ -1023,8 +1023,8 @@ struct FObjectProperty : public FObjectBaseProperty
     FObjectProperty(
         UStruct* InOwnerStruct,
         const char* InPropertyName,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FObjectBaseProperty(InOwnerStruct, InPropertyName, EPropertyType::Object, InSize, InOffset, InFlags)
@@ -1037,8 +1037,8 @@ struct FUnresolvedPtrProperty : public FObjectBaseProperty
     FUnresolvedPtrProperty(
         UStruct* InOwnerStruct,
         const char* InPropertyName,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FObjectBaseProperty(InOwnerStruct, InPropertyName, EPropertyType::UnresolvedPointer, InSize, InOffset, InFlags)
@@ -1054,8 +1054,8 @@ struct FStructProperty : public FProperty
     FStructProperty(
         UStruct* InOwnerStruct,
         const char* InPropertyName,
-        int32 InSize,
-        int32 InOffset,
+        int64 InSize,
+        int64 InOffset,
         EPropertyFlags InFlags
     )
         : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Struct, InSize, InOffset, InFlags)

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
@@ -756,7 +756,7 @@ struct TMapProperty : public FProperty
 
                     if (bIsOpen)
                     {
-                        constexpr std::string_view KeyTypeNameView = GetTypeName<KeyType>();
+                        constexpr std::string_view KeyTypeNameView = GetTypeNameString<KeyType>();
                         std::string KeyTypeName = std::string(KeyTypeNameView);
                         if (ImGui::TreeNode(std::format("Key ({})", KeyTypeName).c_str()))
                         {
@@ -765,7 +765,7 @@ struct TMapProperty : public FProperty
                             ImGui::TreePop();
                         }
 
-                        constexpr std::string_view ValueTypeNameView = GetTypeName<ValueType>();
+                        constexpr std::string_view ValueTypeNameView = GetTypeNameString<ValueType>();
                         std::string ValueTypeName = std::string(ValueTypeNameView);
                         if (ImGui::TreeNode(std::format("Value ({})", ValueTypeName).c_str()))
                         {
@@ -1166,7 +1166,7 @@ FProperty* MakeProperty(
     }
     else if constexpr (TypeEnum == EPropertyType::UnresolvedPointer)
     {
-        constexpr std::string_view TypeName = GetTypeName<T>();
+        constexpr std::string_view TypeName = GetTypeNameString<T>();
         FProperty* Property = new FUnresolvedPtrProperty { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags };
         Property->TypeSpecificData = FName(TypeName.data(), TypeName.size());
         return Property;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
@@ -40,10 +40,10 @@ struct FProperty
     }
 
     virtual ~FProperty() = default;
-    FProperty(const FProperty&) = default;
-    FProperty& operator=(const FProperty&) = default;
-    FProperty(FProperty&&) = default;
-    FProperty& operator=(FProperty&&) = default;
+    FProperty(const FProperty&) = delete;
+    FProperty& operator=(const FProperty&) = delete;
+    FProperty(FProperty&&) = delete;
+    FProperty& operator=(FProperty&&) = delete;
 
 public:
     /** ImGui에 각 프로퍼티에 맞는 UI를 띄웁니다. */
@@ -1051,10 +1051,10 @@ struct FUnresolvedPtrProperty : public FProperty
         delete ResolvedProperty;
     }
 
-    FUnresolvedPtrProperty(const FUnresolvedPtrProperty&) = default;
-    FUnresolvedPtrProperty& operator=(const FUnresolvedPtrProperty&) = default;
-    FUnresolvedPtrProperty(FUnresolvedPtrProperty&&) = default;
-    FUnresolvedPtrProperty& operator=(FUnresolvedPtrProperty&&) = default;
+    FUnresolvedPtrProperty(const FUnresolvedPtrProperty&) = delete;
+    FUnresolvedPtrProperty& operator=(const FUnresolvedPtrProperty&) = delete;
+    FUnresolvedPtrProperty(FUnresolvedPtrProperty&&) = delete;
+    FUnresolvedPtrProperty& operator=(FUnresolvedPtrProperty&&) = delete;
 
     virtual void DisplayInImGui(UObject* Object) const override;
     virtual void Resolve() override;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
@@ -561,7 +561,7 @@ struct TArrayProperty : public FProperty
 
         if (ImGui::TreeNode(PropertyLabel))
         {
-            ImGui::BeginDisabled(HasFlag(Flags, EPropertyFlags::VisibleAnywhere));
+            ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));
             {
                 TArray<ElementType>* Data = static_cast<TArray<ElementType>*>(DataPtr);
 
@@ -681,7 +681,7 @@ struct TMapProperty : public FProperty
 
         if (ImGui::TreeNode(PropertyLabel))
         {
-            ImGui::BeginDisabled(HasFlag(Flags, EPropertyFlags::VisibleAnywhere));
+            ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));
             {
                 const ImGuiIO& IO = ImGui::GetIO();
                 ImFont* IconFont = IO.Fonts->Fonts[1]; // FEATHER_FONT = 1
@@ -832,7 +832,7 @@ struct TSetProperty : public FProperty
     
         if (ImGui::TreeNode(PropertyLabel))
         {
-            ImGui::BeginDisabled(HasFlag(Flags, EPropertyFlags::VisibleAnywhere));
+            ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));
             {
                 const ImGuiIO& IO = ImGui::GetIO();
                 ImFont* IconFont = IO.Fonts->Fonts[1]; // FEATHER_FONT = 1
@@ -945,7 +945,7 @@ struct TEnumProperty : public FProperty
 
     virtual void DisplayInImGui(UObject* Object) const override
     {
-        ImGui::BeginDisabled(HasFlag(Flags, EPropertyFlags::VisibleAnywhere));
+        ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));
         {
             FProperty::DisplayInImGui(Object);
         }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
@@ -2,18 +2,20 @@
 #include <variant>
 #include <optional>
 
-#include "Object.h"
 #include "PropertyTypes.h"
+#include "Struct.h"
 #include "Container/Queue.h"
 #include "Templates/TemplateUtilities.h"
 #include "Templates/TypeUtilities.h"
+
+class UScriptStruct;
 
 
 struct FProperty
 {
     /**
      * 클래스의 프로퍼티를 등록합니다.
-     * @param InOwnerClass 이 프로퍼티를 가지고 있는 UClass
+     * @param InOwnerStruct 이 프로퍼티를 가지고 있는 UStruct
      * @param InPropertyName 프로퍼티의 이름
      * @param InType 프로퍼티의 타입
      * @param InSize 프로퍼티의 크기
@@ -21,14 +23,14 @@ struct FProperty
      * @param InFlags Reflection 관련 Flag
      */
     FProperty(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         EPropertyType InType,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : OwnerClass(InOwnerClass)
+        : OwnerStruct(InOwnerStruct)
         , Name(InPropertyName)
         , Type(InType)
         , Size(InSize)
@@ -133,7 +135,7 @@ protected:
     }
 
 public:
-    UClass* OwnerClass;
+    UStruct* OwnerStruct;
 
     const char* Name;
     EPropertyType Type;
@@ -145,7 +147,7 @@ public:
     std::variant<
         std::monostate,  // 현재 값이 없음을 나타냄
         UClass*,         // FProperty의 Type이 Object일때 원본 Property를 가지고 있는 UClass
-        // FStructInfo*,    // FProperty의 Type이 Struct일때 커스텀 구조체의 정보
+        UScriptStruct*,  // FProperty의 Type이 Struct일때 커스텀 구조체의 정보
         FName            // FProperty의 Type이 UnresolvedPointer일 때 런타임에 검사할 UClass 이름
     > TypeSpecificData;
 };
@@ -154,14 +156,14 @@ public:
 struct FNumericProperty : public FProperty
 {
     FNumericProperty(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         EPropertyType InType,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FProperty(InOwnerClass, InPropertyName, InType, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, InType, InSize, InOffset, InFlags)
     {
     }
 
@@ -171,13 +173,13 @@ struct FNumericProperty : public FProperty
 struct FInt8Property : public FNumericProperty
 {
     FInt8Property(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FNumericProperty(InOwnerClass, InPropertyName, EPropertyType::Int8, InSize, InOffset, InFlags)
+        : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::Int8, InSize, InOffset, InFlags)
     {
     }
 
@@ -187,13 +189,13 @@ struct FInt8Property : public FNumericProperty
 struct FInt16Property : public FNumericProperty
 {
     FInt16Property(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FNumericProperty(InOwnerClass, InPropertyName, EPropertyType::Int16, InSize, InOffset, InFlags)
+        : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::Int16, InSize, InOffset, InFlags)
     {
     }
 
@@ -203,13 +205,13 @@ struct FInt16Property : public FNumericProperty
 struct FInt32Property : public FNumericProperty
 {
     FInt32Property(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FNumericProperty(InOwnerClass, InPropertyName, EPropertyType::Int32, InSize, InOffset, InFlags)
+        : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::Int32, InSize, InOffset, InFlags)
     {
     }
 
@@ -219,13 +221,13 @@ struct FInt32Property : public FNumericProperty
 struct FInt64Property : public FNumericProperty
 {
     FInt64Property(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FNumericProperty(InOwnerClass, InPropertyName, EPropertyType::Int64, InSize, InOffset, InFlags)
+        : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::Int64, InSize, InOffset, InFlags)
     {
     }
 
@@ -235,13 +237,13 @@ struct FInt64Property : public FNumericProperty
 struct FUInt8Property : public FNumericProperty
 {
     FUInt8Property(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FNumericProperty(InOwnerClass, InPropertyName, EPropertyType::UInt8, InSize, InOffset, InFlags)
+        : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::UInt8, InSize, InOffset, InFlags)
     {
     }
 
@@ -251,13 +253,13 @@ struct FUInt8Property : public FNumericProperty
 struct FUInt16Property : public FNumericProperty
 {
     FUInt16Property(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FNumericProperty(InOwnerClass, InPropertyName, EPropertyType::UInt16, InSize, InOffset, InFlags)
+        : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::UInt16, InSize, InOffset, InFlags)
     {
     }
 
@@ -267,13 +269,13 @@ struct FUInt16Property : public FNumericProperty
 struct FUInt32Property : public FNumericProperty
 {
     FUInt32Property(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FNumericProperty(InOwnerClass, InPropertyName, EPropertyType::UInt32, InSize, InOffset, InFlags)
+        : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::UInt32, InSize, InOffset, InFlags)
     {
     }
 
@@ -283,13 +285,13 @@ struct FUInt32Property : public FNumericProperty
 struct FUInt64Property : public FNumericProperty
 {
     FUInt64Property(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FNumericProperty(InOwnerClass, InPropertyName, EPropertyType::UInt64, InSize, InOffset, InFlags)
+        : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::UInt64, InSize, InOffset, InFlags)
     {
     }
 
@@ -299,13 +301,13 @@ struct FUInt64Property : public FNumericProperty
 struct FFloatProperty : public FNumericProperty
 {
     FFloatProperty(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FNumericProperty(InOwnerClass, InPropertyName, EPropertyType::Float, InSize, InOffset, InFlags)
+        : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::Float, InSize, InOffset, InFlags)
     {
     }
 
@@ -315,13 +317,13 @@ struct FFloatProperty : public FNumericProperty
 struct FDoubleProperty : public FNumericProperty
 {
     FDoubleProperty(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FNumericProperty(InOwnerClass, InPropertyName, EPropertyType::Double, InSize, InOffset, InFlags)
+        : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::Double, InSize, InOffset, InFlags)
     {
     }
 
@@ -331,13 +333,13 @@ struct FDoubleProperty : public FNumericProperty
 struct FBoolProperty : public FProperty
 {
     FBoolProperty(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FProperty(InOwnerClass, InPropertyName, EPropertyType::Bool, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Bool, InSize, InOffset, InFlags)
     {
     }
 
@@ -348,13 +350,13 @@ struct FBoolProperty : public FProperty
 struct FStrProperty : public FProperty
 {
     FStrProperty(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FProperty(InOwnerClass, InPropertyName, EPropertyType::String, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::String, InSize, InOffset, InFlags)
     {
     }
 
@@ -365,13 +367,13 @@ struct FStrProperty : public FProperty
 struct FNameProperty : public FProperty
 {
     FNameProperty(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FProperty(InOwnerClass, InPropertyName, EPropertyType::Name, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Name, InSize, InOffset, InFlags)
     {}
 
     virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override;
@@ -380,13 +382,13 @@ struct FNameProperty : public FProperty
 struct FVector2DProperty : public FProperty
 {
     FVector2DProperty(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FProperty(InOwnerClass, InPropertyName, EPropertyType::Vector2D, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Vector2D, InSize, InOffset, InFlags)
     {
     }
 
@@ -397,13 +399,13 @@ struct FVector2DProperty : public FProperty
 struct FVectorProperty : public FProperty
 {
     FVectorProperty(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FProperty(InOwnerClass, InPropertyName, EPropertyType::Vector, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Vector, InSize, InOffset, InFlags)
     {
     }
 
@@ -414,13 +416,13 @@ struct FVectorProperty : public FProperty
 struct FVector4Property : public FProperty
 {
     FVector4Property(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FProperty(InOwnerClass, InPropertyName, EPropertyType::Vector4, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Vector4, InSize, InOffset, InFlags)
     {
     }
 
@@ -431,13 +433,13 @@ struct FVector4Property : public FProperty
 struct FRotatorProperty : public FProperty
 {
     FRotatorProperty(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FProperty(InOwnerClass, InPropertyName, EPropertyType::Rotator, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Rotator, InSize, InOffset, InFlags)
     {
     }
 
@@ -448,13 +450,13 @@ struct FRotatorProperty : public FProperty
 struct FQuatProperty : public FProperty
 {
     FQuatProperty(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FProperty(InOwnerClass, InPropertyName, EPropertyType::Quat, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Quat, InSize, InOffset, InFlags)
     {
     }
 
@@ -465,13 +467,13 @@ struct FQuatProperty : public FProperty
 struct FTransformProperty : public FProperty
 {
     FTransformProperty(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FProperty(InOwnerClass, InPropertyName, EPropertyType::Transform, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Transform, InSize, InOffset, InFlags)
     {
     }
 
@@ -481,13 +483,13 @@ struct FTransformProperty : public FProperty
 struct FMatrixProperty : public FProperty
 {
     FMatrixProperty(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FProperty(InOwnerClass, InPropertyName, EPropertyType::Matrix, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Matrix, InSize, InOffset, InFlags)
     {
     }
 
@@ -497,13 +499,13 @@ struct FMatrixProperty : public FProperty
 struct FColorProperty : public FProperty
 {
     FColorProperty(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FProperty(InOwnerClass, InPropertyName, EPropertyType::Color, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Color, InSize, InOffset, InFlags)
     {
     }
 
@@ -514,13 +516,13 @@ struct FColorProperty : public FProperty
 struct FLinearColorProperty : public FProperty
 {
     FLinearColorProperty(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FProperty(InOwnerClass, InPropertyName, EPropertyType::LinearColor, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::LinearColor, InSize, InOffset, InFlags)
     {
     }
 
@@ -536,13 +538,13 @@ struct TArrayProperty : public FProperty
     FProperty* ElementProperty = nullptr;
 
     TArrayProperty(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FProperty(InOwnerClass, InPropertyName, EPropertyType::Array, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Array, InSize, InOffset, InFlags)
     {
     }
 
@@ -656,13 +658,13 @@ struct TMapProperty : public FProperty
     FProperty* ValueProperty = nullptr;
 
     TMapProperty(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FProperty(InOwnerClass, InPropertyName, EPropertyType::Map, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Map, InSize, InOffset, InFlags)
     {
     }
 
@@ -807,13 +809,13 @@ struct TSetProperty : public FProperty
     FProperty* ElementProperty = nullptr;
 
     TSetProperty(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FProperty(InOwnerClass, InPropertyName, EPropertyType::Set, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Set, InSize, InOffset, InFlags)
     {
     }
 
@@ -931,13 +933,13 @@ struct TEnumProperty : public FProperty
     using EnumType = InEnumType;
 
     TEnumProperty(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FProperty(InOwnerClass, InPropertyName, EPropertyType::Enum, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Enum, InSize, InOffset, InFlags)
     {
     }
 
@@ -985,13 +987,13 @@ struct TEnumProperty : public FProperty
 struct FSubclassOfProperty : public FProperty
 {
     FSubclassOfProperty(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FProperty(InOwnerClass, InPropertyName, EPropertyType::SubclassOf, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::SubclassOf, InSize, InOffset, InFlags)
     {
     }
 
@@ -1002,14 +1004,14 @@ struct FSubclassOfProperty : public FProperty
 struct FObjectBaseProperty : public FProperty
 {
     FObjectBaseProperty(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         EPropertyType InType,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FProperty(InOwnerClass, InPropertyName, InType, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, InType, InSize, InOffset, InFlags)
     {
     }
 
@@ -1019,13 +1021,13 @@ struct FObjectBaseProperty : public FProperty
 struct FObjectProperty : public FObjectBaseProperty
 {
     FObjectProperty(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FObjectBaseProperty(InOwnerClass, InPropertyName, EPropertyType::Object, InSize, InOffset, InFlags)
+        : FObjectBaseProperty(InOwnerStruct, InPropertyName, EPropertyType::Object, InSize, InOffset, InFlags)
     {
     }
 };
@@ -1033,13 +1035,13 @@ struct FObjectProperty : public FObjectBaseProperty
 struct FUnresolvedPtrProperty : public FObjectBaseProperty
 {
     FUnresolvedPtrProperty(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FObjectBaseProperty(InOwnerClass, InPropertyName, EPropertyType::UnresolvedPointer, InSize, InOffset, InFlags)
+        : FObjectBaseProperty(InOwnerStruct, InPropertyName, EPropertyType::UnresolvedPointer, InSize, InOffset, InFlags)
     {
     }
 
@@ -1050,13 +1052,13 @@ struct FUnresolvedPtrProperty : public FObjectBaseProperty
 struct FStructProperty : public FProperty
 {
     FStructProperty(
-        UClass* InOwnerClass,
+        UStruct* InOwnerStruct,
         const char* InPropertyName,
         int32 InSize,
         int32 InOffset,
         EPropertyFlags InFlags
     )
-        : FProperty(InOwnerClass, InPropertyName, EPropertyType::Struct, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Struct, InSize, InOffset, InFlags)
     {
     }
 };
@@ -1073,7 +1075,7 @@ FProperty* CreatePropertyForContainerType();
 
 template <typename T, EPropertyFlags InFlags>
 FProperty* MakeProperty(
-    UClass* InOwnerClass,
+    UStruct* InOwnerStruct,
     const char* InPropertyName,
     int32 InOffset
 )
@@ -1093,57 +1095,57 @@ FProperty* MakeProperty(
     // 각 타입에 맞는 Property 생성
     constexpr EPropertyType TypeEnum = GetPropertyType<T>();
 
-    if constexpr      (TypeEnum == EPropertyType::Int8)        { return new FInt8Property        { InOwnerClass, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Int16)       { return new FInt16Property       { InOwnerClass, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Int32)       { return new FInt32Property       { InOwnerClass, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Int64)       { return new FInt64Property       { InOwnerClass, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::UInt8)       { return new FUInt8Property       { InOwnerClass, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::UInt16)      { return new FUInt16Property      { InOwnerClass, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::UInt32)      { return new FUInt32Property      { InOwnerClass, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::UInt64)      { return new FUInt64Property      { InOwnerClass, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Float)       { return new FFloatProperty       { InOwnerClass, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Double)      { return new FDoubleProperty      { InOwnerClass, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Bool)        { return new FBoolProperty        { InOwnerClass, InPropertyName, sizeof(T), InOffset, InFlags }; }
+    if constexpr      (TypeEnum == EPropertyType::Int8)        { return new FInt8Property        { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
+    else if constexpr (TypeEnum == EPropertyType::Int16)       { return new FInt16Property       { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
+    else if constexpr (TypeEnum == EPropertyType::Int32)       { return new FInt32Property       { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
+    else if constexpr (TypeEnum == EPropertyType::Int64)       { return new FInt64Property       { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
+    else if constexpr (TypeEnum == EPropertyType::UInt8)       { return new FUInt8Property       { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
+    else if constexpr (TypeEnum == EPropertyType::UInt16)      { return new FUInt16Property      { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
+    else if constexpr (TypeEnum == EPropertyType::UInt32)      { return new FUInt32Property      { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
+    else if constexpr (TypeEnum == EPropertyType::UInt64)      { return new FUInt64Property      { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
+    else if constexpr (TypeEnum == EPropertyType::Float)       { return new FFloatProperty       { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
+    else if constexpr (TypeEnum == EPropertyType::Double)      { return new FDoubleProperty      { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
+    else if constexpr (TypeEnum == EPropertyType::Bool)        { return new FBoolProperty        { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
 
-    else if constexpr (TypeEnum == EPropertyType::String)      { return new FStrProperty         { InOwnerClass, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Name)        { return new FNameProperty        { InOwnerClass, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Vector2D)    { return new FVector2DProperty    { InOwnerClass, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Vector)      { return new FVectorProperty      { InOwnerClass, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Vector4)     { return new FVector4Property     { InOwnerClass, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Rotator)     { return new FRotatorProperty     { InOwnerClass, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Quat)        { return new FQuatProperty        { InOwnerClass, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Transform)   { return new FTransformProperty   { InOwnerClass, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Matrix)      { return new FMatrixProperty      { InOwnerClass, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Color)       { return new FColorProperty       { InOwnerClass, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::LinearColor) { return new FLinearColorProperty { InOwnerClass, InPropertyName, sizeof(T), InOffset, InFlags }; }
+    else if constexpr (TypeEnum == EPropertyType::String)      { return new FStrProperty         { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
+    else if constexpr (TypeEnum == EPropertyType::Name)        { return new FNameProperty        { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
+    else if constexpr (TypeEnum == EPropertyType::Vector2D)    { return new FVector2DProperty    { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
+    else if constexpr (TypeEnum == EPropertyType::Vector)      { return new FVectorProperty      { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
+    else if constexpr (TypeEnum == EPropertyType::Vector4)     { return new FVector4Property     { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
+    else if constexpr (TypeEnum == EPropertyType::Rotator)     { return new FRotatorProperty     { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
+    else if constexpr (TypeEnum == EPropertyType::Quat)        { return new FQuatProperty        { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
+    else if constexpr (TypeEnum == EPropertyType::Transform)   { return new FTransformProperty   { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
+    else if constexpr (TypeEnum == EPropertyType::Matrix)      { return new FMatrixProperty      { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
+    else if constexpr (TypeEnum == EPropertyType::Color)       { return new FColorProperty       { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
+    else if constexpr (TypeEnum == EPropertyType::LinearColor) { return new FLinearColorProperty { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
 
     else if constexpr (TypeEnum == EPropertyType::Array)
     {
-        TArrayProperty<T>* Property = new TArrayProperty<T> { InOwnerClass, InPropertyName, sizeof(T), InOffset, InFlags };
+        TArrayProperty<T>* Property = new TArrayProperty<T> { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags };
         Property->ElementProperty = CreatePropertyForContainerType<typename T::ElementType, InFlags>();
         return Property;
     }
     else if constexpr (TypeEnum == EPropertyType::Map)
     {
-        TMapProperty<T>* Property = new TMapProperty<T> { InOwnerClass, InPropertyName, sizeof(T), InOffset, InFlags };
+        TMapProperty<T>* Property = new TMapProperty<T> { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags };
         Property->KeyProperty = CreatePropertyForContainerType<typename T::KeyType, InFlags>();
         Property->ValueProperty = CreatePropertyForContainerType<typename T::ValueType, InFlags>();
         return Property;
     }
     else if constexpr (TypeEnum == EPropertyType::Set)
     {
-        TSetProperty<T>* Property = new TSetProperty<T> { InOwnerClass, InPropertyName, sizeof(T), InOffset, InFlags };
+        TSetProperty<T>* Property = new TSetProperty<T> { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags };
         Property->ElementProperty = CreatePropertyForContainerType<typename T::ElementType, InFlags>();
         return Property;
     }
 
-    else if constexpr (TypeEnum == EPropertyType::Enum)        { return new TEnumProperty<T>     { InOwnerClass, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Struct)      { return new FStructProperty      { InOwnerClass, InPropertyName, sizeof(T), InOffset, InFlags }; }
+    else if constexpr (TypeEnum == EPropertyType::Enum)        { return new TEnumProperty<T>     { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
+    else if constexpr (TypeEnum == EPropertyType::Struct)      { return new FStructProperty      { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
     else if constexpr (TypeEnum == EPropertyType::SubclassOf)
     {
         if constexpr (std::derived_from<typename T::ElementType, UObject>)
         {
-            FProperty* Property = new FSubclassOfProperty { InOwnerClass, InPropertyName, sizeof(T), InOffset, InFlags };
+            FProperty* Property = new FSubclassOfProperty { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags };
             Property->TypeSpecificData = T::ElementType::StaticClass();
             return Property;
         }
@@ -1156,7 +1158,7 @@ FProperty* MakeProperty(
     else if constexpr (TypeEnum == EPropertyType::Object)
     {
         using PointerType = std::remove_cvref_t<std::remove_pointer_t<T>>;
-        FProperty* Property = new FObjectProperty { InOwnerClass, InPropertyName, sizeof(T), InOffset, InFlags };
+        FProperty* Property = new FObjectProperty { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags };
 
         // Property륻 등록하는 시점에서는 아직 모든 UClass가 초기화되지 않았으므로, UEngine::Init()때 Property의 TypeName을 바탕으로 ClassMap에서 가져오기
         Property->TypeSpecificData = PointerType::StaticClass();
@@ -1165,7 +1167,7 @@ FProperty* MakeProperty(
     else if constexpr (TypeEnum == EPropertyType::UnresolvedPointer)
     {
         constexpr std::string_view TypeName = GetTypeName<T>();
-        FProperty* Property = new FUnresolvedPtrProperty { InOwnerClass, InPropertyName, sizeof(T), InOffset, InFlags };
+        FProperty* Property = new FUnresolvedPtrProperty { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags };
         Property->TypeSpecificData = FName(TypeName.data(), TypeName.size());
         return Property;
     }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
@@ -1,6 +1,7 @@
 ﻿#include "Property.h"
 
 #include "Class.h"
+#include "ScriptStruct.h"
 #include "UObjectHash.h"
 #include "Editor/UnrealEd/ImGuiWidget.h"
 #include "Math/NumericLimits.h"
@@ -499,6 +500,24 @@ void FObjectProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* Dat
             }
         }
         ImGui::TreePop();
+    }
+}
+
+void FStructProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const
+{
+    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
+
+    if (UScriptStruct* const* StructType = std::get_if<UScriptStruct*>(&TypeSpecificData))
+    {
+        if (ImGui::TreeNodeEx(PropertyLabel, ImGuiTreeNodeFlags_Framed | ImGuiTreeNodeFlags_DefaultOpen))
+        {
+            for (const FProperty* Property : (*StructType)->GetProperties())
+            {
+                void* Data = static_cast<std::byte*>(DataPtr) + Property->Offset;
+                Property->DisplayRawDataInImGui(Property->Name, Data);
+            }
+            ImGui::TreePop();
+        }
     }
 }
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
@@ -473,14 +473,14 @@ void FObjectProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* Dat
 
                 if (ImGui::BeginCombo(std::format("##{}", PropertyLabel).c_str(), (*Object)->GetName().ToAnsiString().c_str()))
                 {
-                    for (const UObject* ChildObject : ChildObjects)
+                    for (UObject* ChildObject : ChildObjects)
                     {
                         const std::string ObjectName = ChildObject->GetName().ToAnsiString();
                         const bool bIsSelected = ChildObject == *Object;
                         if (ImGui::Selectable(ObjectName.c_str(), bIsSelected))
                         {
                             // TODO: 나중에 수정, 지금은 목록만 보여주고, 설정은 안함
-                            // *Object = ChildObject;
+                            *Object = ChildObject;
                         }
                         if (bIsSelected)
                         {
@@ -493,9 +493,13 @@ void FObjectProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* Dat
             }
             else if (HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere))
             {
-                for (const FProperty* Prop : ObjectClass->GetProperties())
+                const UClass* ChildClass = ObjectClass;
+                for (; ChildClass; ChildClass = ChildClass->GetSuperClass())
                 {
-                    Prop->DisplayInImGui(*Object);
+                    for (const FProperty* Prop : ChildClass->GetProperties())
+                    {
+                        Prop->DisplayInImGui(*Object);
+                    }
                 }
             }
         }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
@@ -470,7 +470,7 @@ void FObjectProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* Dat
                 TArray<UObject*> ChildObjects;
                 GetObjectsOfClass(ObjectClass, ChildObjects, true);
 
-                if (ImGui::BeginCombo(std::format("##{}", PropertyLabel).c_str(), ObjectClass->GetName().ToAnsiString().c_str()))
+                if (ImGui::BeginCombo(std::format("##{}", PropertyLabel).c_str(), (*Object)->GetName().ToAnsiString().c_str()))
                 {
                     for (const UObject* ChildObject : ChildObjects)
                     {

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
@@ -454,7 +454,7 @@ void FSubclassOfProperty::DisplayRawDataInImGui(const char* PropertyLabel, void*
     }
 }
 
-void FObjectBaseProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const
+void FObjectProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const
 {
     FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
 
@@ -504,8 +504,9 @@ void FObjectBaseProperty::DisplayRawDataInImGui(const char* PropertyLabel, void*
 
 void FUnresolvedPtrProperty::DisplayInImGui(UObject* Object) const
 {
-    if (Type == EPropertyType::Object)
+    if (Type == EPropertyType::Unknown)
     {
-        FObjectBaseProperty::DisplayInImGui(Object);
+        return;
     }
+    ResolvedProperty->DisplayInImGui(Object);
 }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
@@ -63,7 +63,7 @@ void FProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) 
 
 void FNumericProperty::DisplayInImGui(UObject* Object) const
 {
-    ImGui::BeginDisabled(HasFlag(Flags, EPropertyFlags::VisibleAnywhere));
+    ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));
     {
         FProperty::DisplayInImGui(Object);
     }
@@ -142,7 +142,7 @@ void FDoubleProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* Dat
 
 void FBoolProperty::DisplayInImGui(UObject* Object) const
 {
-    ImGui::BeginDisabled(HasFlag(Flags, EPropertyFlags::VisibleAnywhere));
+    ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));
     {
         FProperty::DisplayInImGui(Object);
     }
@@ -158,7 +158,7 @@ void FBoolProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataP
 
 void FStrProperty::DisplayInImGui(UObject* Object) const
 {
-    ImGui::BeginDisabled(HasFlag(Flags, EPropertyFlags::VisibleAnywhere));
+    ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));
     {
         FProperty::DisplayInImGui(Object);
     }
@@ -202,7 +202,7 @@ void FNameProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataP
 
 void FVector2DProperty::DisplayInImGui(UObject* Object) const
 {
-    ImGui::BeginDisabled(HasFlag(Flags, EPropertyFlags::VisibleAnywhere));
+    ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));
     {
         FProperty::DisplayInImGui(Object);
     }
@@ -218,7 +218,7 @@ void FVector2DProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* D
 
 void FVectorProperty::DisplayInImGui(UObject* Object) const
 {
-    ImGui::BeginDisabled(HasFlag(Flags, EPropertyFlags::VisibleAnywhere));
+    ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));
     {
         FProperty::DisplayInImGui(Object);
     }
@@ -234,7 +234,7 @@ void FVectorProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* Dat
 
 void FVector4Property::DisplayInImGui(UObject* Object) const
 {
-    ImGui::BeginDisabled(HasFlag(Flags, EPropertyFlags::VisibleAnywhere));
+    ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));
     {
         FProperty::DisplayInImGui(Object);
     }
@@ -250,7 +250,7 @@ void FVector4Property::DisplayRawDataInImGui(const char* PropertyLabel, void* Da
 
 void FRotatorProperty::DisplayInImGui(UObject* Object) const
 {
-    ImGui::BeginDisabled(HasFlag(Flags, EPropertyFlags::VisibleAnywhere));
+    ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));
     {
         FProperty::DisplayInImGui(Object);
     }
@@ -266,7 +266,7 @@ void FRotatorProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* Da
 
 void FQuatProperty::DisplayInImGui(UObject* Object) const
 {
-    ImGui::BeginDisabled(HasFlag(Flags, EPropertyFlags::VisibleAnywhere));
+    ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));
     {
         FProperty::DisplayInImGui(Object);
     }
@@ -286,7 +286,7 @@ void FTransformProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* 
 
     if (ImGui::TreeNode(PropertyLabel))
     {
-        ImGui::BeginDisabled(HasFlag(Flags, EPropertyFlags::VisibleAnywhere));
+        ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));
         {
             FTransform* Data = static_cast<FTransform*>(DataPtr);
             FRotator Rotation = Data->Rotator();
@@ -312,7 +312,7 @@ void FMatrixProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* Dat
         bool bChanged = false;
         FMatrix* Data = static_cast<FMatrix*>(DataPtr);
 
-        ImGui::BeginDisabled(HasFlag(Flags, EPropertyFlags::VisibleAnywhere));
+        ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));
         {
             FTransform Transform = FTransform(*Data);
             FRotator Rotation = Transform.Rotator();
@@ -333,7 +333,7 @@ void FMatrixProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* Dat
 
         if (ImGui::TreeNode("Advanced"))
         {
-            ImGui::BeginDisabled(HasFlag(Flags, EPropertyFlags::VisibleAnywhere));
+            ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));
             {
                 ImGui::DragFloat4("##1", Data->M[0], 0.01f, -FLT_MAX, FLT_MAX, "%.3f");
                 ImGui::DragFloat4("##2", Data->M[1], 0.01f, -FLT_MAX, FLT_MAX, "%.3f");
@@ -350,7 +350,7 @@ void FMatrixProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* Dat
 
 void FColorProperty::DisplayInImGui(UObject* Object) const
 {
-    ImGui::BeginDisabled(HasFlag(Flags, EPropertyFlags::VisibleAnywhere));
+    ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));
     {
         FProperty::DisplayInImGui(Object);
     }
@@ -380,7 +380,7 @@ void FColorProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* Data
 
 void FLinearColorProperty::DisplayInImGui(UObject* Object) const
 {
-    ImGui::BeginDisabled(HasFlag(Flags, EPropertyFlags::VisibleAnywhere));
+    ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));
     {
         FProperty::DisplayInImGui(Object);
     }
@@ -406,7 +406,7 @@ void FLinearColorProperty::DisplayRawDataInImGui(const char* PropertyLabel, void
 
 void FSubclassOfProperty::DisplayInImGui(UObject* Object) const
 {
-    ImGui::BeginDisabled(HasFlag(Flags, EPropertyFlags::VisibleAnywhere));
+    ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));
     {
         FProperty::DisplayInImGui(Object);
     }
@@ -465,7 +465,7 @@ void FObjectBaseProperty::DisplayRawDataInImGui(const char* PropertyLabel, void*
         if (const UClass* ObjectClass = IsValid(*Object) ? (*Object)->GetClass() : nullptr)
         {
             // 포인터가 가리키는것을 수정할 때, 보통 UObject의 인스턴스
-            if (HasFlag(Flags, EPropertyFlags::EditAnywhere))
+            if (HasAnyFlags(Flags, EPropertyFlags::EditAnywhere))
             {
                 TArray<UObject*> ChildObjects;
                 GetObjectsOfClass(ObjectClass, ChildObjects, true);
@@ -490,7 +490,7 @@ void FObjectBaseProperty::DisplayRawDataInImGui(const char* PropertyLabel, void*
                     ImGui::EndCombo();
                 }
             }
-            else if (HasFlag(Flags, EPropertyFlags::VisibleAnywhere))
+            else if (HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere))
             {
                 for (const FProperty* Prop : ObjectClass->GetProperties())
                 {

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
@@ -464,7 +464,7 @@ void FObjectProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* Dat
 
         if (const UClass* ObjectClass = IsValid(*Object) ? (*Object)->GetClass() : nullptr)
         {
-            // 포인터가 가리키는것을 수정할 때, 보통 UObject의 인스턴스
+            // 포인터가 가리키는 객체를 수정, 여기서는 UObject의 인스턴스
             if (HasAnyFlags(Flags, EPropertyFlags::EditAnywhere))
             {
                 TArray<UObject*> ChildObjects;
@@ -472,7 +472,7 @@ void FObjectProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* Dat
 
                 if (ImGui::BeginCombo(std::format("##{}", PropertyLabel).c_str(), ObjectClass->GetName().ToAnsiString().c_str()))
                 {
-                    for (UObject* ChildObject : ChildObjects)
+                    for (const UObject* ChildObject : ChildObjects)
                     {
                         const std::string ObjectName = ChildObject->GetName().ToAnsiString();
                         const bool bIsSelected = ChildObject == *Object;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyTypes.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyTypes.h
@@ -178,17 +178,6 @@ constexpr bool HasAnyFlags(EPropertyFlags FlagToCheck)
     return HasAnyFlags(Flags, FlagToCheck);
 }
 
-constexpr bool HasFlag(EPropertyFlags Flags, EPropertyFlags FlagToCheck)
-{
-    return HasAllFlags(Flags, FlagToCheck);
-}
-
-template <EPropertyFlags Flags>
-constexpr bool HasFlag(EPropertyFlags FlagToCheck)
-{
-    return HasFlag(Flags, FlagToCheck);
-}
-
 // 특정 플래그만 제외하는 연산자
 constexpr EPropertyFlags operator~(EPropertyFlags Flags)
 {

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyTypes.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyTypes.h
@@ -93,7 +93,7 @@ consteval EPropertyType GetPropertyType()
         }
 
         // 커스텀 구조체 포인터
-        else if constexpr (std::is_class_v<T> && requires { PointedToType::StaticStruct(); })
+        else if constexpr (std::is_class_v<PointedToType> && requires { PointedToType::StaticStruct(); })
         {
             return EPropertyType::StructPointer;
         }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyTypes.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyTypes.h
@@ -39,6 +39,7 @@ enum class EPropertyType : uint8
 
     Enum,                          // 커스텀 Enum 타입
     Struct,                        // 사용자 정의 구조체 타입
+    StructPointer,                 // 사용자 정의 구조체 포인터 타입
     SubclassOf,                    // TSubclassOf
     Object,                        // UObject* 타입
 };
@@ -91,6 +92,12 @@ consteval EPropertyType GetPropertyType()
             return EPropertyType::Object;
         }
 
+        // 커스텀 구조체 포인터
+        else if constexpr (std::is_class_v<T> && requires { PointedToType::StaticStruct(); })
+        {
+            return EPropertyType::StructPointer;
+        }
+
         // 전방 선언된 타입이 들어올 경우, 상속관계를 확인할 수 없음
         // 이때는 UObject일 확률도 있기 때문에 런타임에 검사
         return EPropertyType::UnresolvedPointer;
@@ -104,21 +111,24 @@ consteval EPropertyType GetPropertyType()
     // enum class만 지원
     else if constexpr (std::is_scoped_enum_v<T>)    { return EPropertyType::Enum;   }
 
-    // 리플렉션 시스템에 등록된 커스텀 구조체 (StructTraits 또는 유사한 메커니즘 사용)
-    // 이때 T가 UObject 값 타입이 아니어야 함 (UObject 값 타입은 보통 프로퍼티로 사용 안 함)
-    // else if constexpr (TStructTraits<T>::bIsReflectedStruct && !std::is_base_of_v<UObject, T>)
-    // {
-    //     if (OutUnresolvedTypeName) { *OutUnresolvedTypeName = GetTypeNameString<T>(); } // 경우에 따라 이름 필요
-    //     return EPropertyType::Struct; // 또는 StructTraits에 UnresolvedStruct 플래그가 있다면 그것 사용
-    // }
-
     // 커스텀 구조체
-    // else if constexpr (std::is_class_v<T> && !std::derived_from<T, UObject>)
-    // {
-    //     // TODO: 임시용
-    //     // 나중에 커스텀 구조체 타입에 대해서 만들어야함
-    //     return EPropertyType::Struct;
-    // }
+    else if constexpr (std::is_class_v<T> && !std::derived_from<T, UObject>)
+    {
+        if constexpr (requires { T::StaticStruct(); })
+        {
+            return EPropertyType::Struct;
+        }
+        else
+        {
+            // Reflection System에 등록이 되어있지 않은 구조체면 컴파일 에러
+            static_assert(
+                TAlwaysFalse<T>,
+                "The type T is not registered in the reflection system. "
+                "Make sure to register it using DECLARE_STRUCT() macro or provide StaticStruct() function."
+            );
+            return EPropertyType::Unknown;
+        }
+    }
 
     else
     {

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyTypes.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyTypes.h
@@ -95,6 +95,10 @@ consteval EPropertyType GetPropertyType()
         // 커스텀 구조체 포인터
         else if constexpr (std::is_class_v<PointedToType> && requires { PointedToType::StaticStruct(); })
         {
+            // 언리얼에서도 커스텀 구조체 포인터에 대해서 지원 안하길래,
+            // UI 구현하기 귀찮으니까 그냥 static_assert를 넣었습니다.
+            // static_assert 지워도 리플렉션 시스템에 정상 등록은 되지만, UI는 뜨지 않습니다.
+            static_assert(TAlwaysFalse<T>, "Custom struct pointer types are not supported.");
             return EPropertyType::StructPointer;
         }
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ScriptStruct.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ScriptStruct.cpp
@@ -1,0 +1,12 @@
+﻿#include "ScriptStruct.h"
+
+
+UScriptStruct::UScriptStruct(
+    const char* InName,
+    uint32 InStructSize,
+    uint32 InAlignment,
+    UScriptStruct* InSuperScriptStruct
+)
+    : UStruct(InName, InStructSize, InAlignment, InSuperScriptStruct)
+{
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ScriptStruct.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ScriptStruct.cpp
@@ -10,3 +10,18 @@ UScriptStruct::UScriptStruct(
     : UStruct(InName, InStructSize, InAlignment, InSuperScriptStruct)
 {
 }
+
+TMap<FName, UScriptStruct*>& UScriptStruct::GetScriptStructMap()
+{
+    static TMap<FName, UScriptStruct*> GScriptStructMap;
+    return GScriptStructMap;
+}
+
+UScriptStruct* UScriptStruct::FindScriptStruct(const FName& StructName)
+{
+    if (UScriptStruct*const* FoundStruct = GetScriptStructMap().Find(StructName))
+    {
+        return *FoundStruct;
+    }
+    return nullptr;
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ScriptStruct.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ScriptStruct.h
@@ -1,0 +1,27 @@
+﻿#pragma once
+#include "Struct.h"
+
+
+/**
+ * C++ DECLARE_STRUCT() 매크로로 정의된 사용자 정의 구조체에 대한 메타데이터를 나타냅니다.
+ */
+class UScriptStruct : public UStruct
+{
+public:
+    UScriptStruct(
+        const char* InName,
+        uint32 InStructSize,
+        uint32 InAlignment,
+        UScriptStruct* InSuperScriptStruct // C++ 구조체도 상속 가능 (선택적, 보통은 nullptr)
+    );
+
+    virtual ~UScriptStruct() override = default;
+
+    UScriptStruct(const UScriptStruct&) = delete;
+    UScriptStruct& operator=(const UScriptStruct&) = delete;
+    UScriptStruct(UScriptStruct&&) = delete;
+    UScriptStruct& operator=(UScriptStruct&&) = delete;
+
+    using Super = UStruct;
+    using ThisClass = UScriptStruct;
+};

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ScriptStruct.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ScriptStruct.h
@@ -24,4 +24,11 @@ public:
 
     using Super = UStruct;
     using ThisClass = UScriptStruct;
+
+public:
+    // 전역 ScriptStruct 맵 접근
+    static TMap<FName, UScriptStruct*>& GetScriptStructMap();
+
+    // 이름으로 ScriptStruct 찾기
+    static UScriptStruct* FindScriptStruct(const FName& StructName);
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Struct.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Struct.cpp
@@ -23,13 +23,13 @@ void UStruct::ResolvePendingProperties()
 }
 
 UStruct::UStruct(
-    const FName& InName,
+    const char* InName,
     uint32 InStructSize,
     uint32 InAlignment,
     UStruct* InSuperStruct
 )
-    : StructSize(InStructSize)
-    , StructAlignment(InAlignment)
+    : PropertiesSize(InStructSize)
+    , MinAlignment(InAlignment)
     , SuperStruct(InSuperStruct)
 {
     NamePrivate = InName;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Struct.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Struct.cpp
@@ -1,0 +1,122 @@
+﻿#include "Struct.h"
+#include "Property.h"
+#include "Serialization/Archive.h"
+
+
+// 정적 멤버 변수 정의
+TArray<FProperty*>& UStruct::GetUnresolvedProperties()
+{
+    static TArray<FProperty*> GUnresolvedProperties;
+    return GUnresolvedProperties;
+}
+
+void UStruct::ResolvePendingProperties()
+{
+    for (FProperty* Prop : GetUnresolvedProperties())
+    {
+        if (Prop)
+        {
+            Prop->Resolve();
+        }
+    }
+    GetUnresolvedProperties().Empty();
+}
+
+UStruct::UStruct(
+    const FName& InName,
+    uint32 InStructSize,
+    uint32 InAlignment,
+    UStruct* InSuperStruct
+)
+    : StructSize(InStructSize)
+    , StructAlignment(InAlignment)
+    , SuperStruct(InSuperStruct)
+{
+    NamePrivate = InName;
+}
+
+UStruct::~UStruct()
+{
+    // Properties 배열에 있는 FProperty 객체들의 메모리 해제
+    for (const FProperty* Prop : Properties)
+    {
+        delete Prop;
+    }
+    Properties.Empty();
+    PropertyMap.Empty();
+}
+
+bool UStruct::IsChildOf(const UStruct* SomeBase) const
+{
+    if (SomeBase == nullptr)
+    {
+        return false;
+    }
+    for (const UStruct* TempStruct = this; TempStruct != nullptr; TempStruct = TempStruct->GetSuperStruct())
+    {
+        if (TempStruct == SomeBase)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+void UStruct::AddProperty(FProperty* Prop)
+{
+    if (!Prop)
+    {
+        return;
+    }
+
+    if (Prop->Type == EPropertyType::UnresolvedPointer)
+    {
+        GetUnresolvedProperties().Add(Prop);
+    }
+
+    Properties.Add(Prop);
+    PropertyMap.Add(FName(Prop->Name), Prop);
+}
+
+FProperty* UStruct::FindPropertyByName(const FName& InName) const
+{
+    if (FProperty* const* FoundProperty = PropertyMap.Find(InName))
+    {
+        return *FoundProperty;
+    }
+
+    if (SuperStruct)
+    {
+        return SuperStruct->FindPropertyByName(InName);
+    }
+
+    return nullptr;
+}
+
+void UStruct::SerializeBin(FArchive& Ar, void* Data)
+{
+    // 부모 Struct의 프로퍼티 먼저 직렬화
+    if (SuperStruct)
+    {
+        SuperStruct->SerializeBin(Ar, Data);
+    }
+
+    // 이 Struct에 직접 정의된 프로퍼티들 직렬화
+    for (const FProperty* Prop : Properties)
+    {
+        if (Prop)
+        {
+            // 프로퍼티가 실제로 데이터 컨테이너(Data) 내에 유효한 오프셋을 가지는지 확인 필요
+            // 예를 들어, 에디터 전용 프로퍼티인데 런타임 데이터에는 없을 수 있음 (그런 경우 Flags로 구분)
+            void* PropData = static_cast<std::byte*>(Data) + Prop->Offset;
+
+            // TODO: FProperty 자체에 SerializeValue(FArchive& Ar, void* ValueData) 같은 가상 함수를 만들고 호출하는 것이 더 좋음
+            // 현재는 UClass의 SerializeBin과 유사하게 크기만큼 직접 직렬화
+            // 이는 FProperty의 실제 타입(FIntProperty, FObjectProperty 등)에 따른 특화된 직렬화 로직이 없음을 의미.
+            // 예를 들어 FObjectProperty는 포인터 자체를 직렬화하는게 아니라, 참조하는 UObject를 찾아 직렬화해야 함.
+            // 이 부분은 FProperty 파생 클래스에서 SerializeValue를 오버라이드하여 구현해야 합니다.
+            // 여기서는 임시로 단순 메모리 복사 형태로 가정. (실제로는 매우 위험)
+            Ar.Serialize(PropData, Prop->Size);
+        }
+    }
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Struct.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Struct.cpp
@@ -28,7 +28,7 @@ UStruct::UStruct(
     uint32 InAlignment,
     UStruct* InSuperStruct
 )
-    : PropertiesSize(InStructSize)
+    : StructSize(InStructSize)
     , MinAlignment(InAlignment)
     , SuperStruct(InSuperStruct)
 {
@@ -74,6 +74,7 @@ void UStruct::AddProperty(FProperty* Prop)
         GetUnresolvedProperties().Add(Prop);
     }
 
+    PropertiesSize += Prop->Size;
     Properties.Add(Prop);
     PropertyMap.Add(FName(Prop->Name), Prop);
 }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Struct.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Struct.h
@@ -90,3 +90,36 @@ bool UStruct::IsChildOf() const
 {
     return IsChildOf(T::StaticClass());
 }
+
+
+/**
+ * T가 UClass인지 UScriptStruct인지에 따라 각각의 StaticClass() 또는 StaticStruct()를 호출합니다.
+ * @tparam T UClass 또는 UScriptStruct 타입
+ * @return T의 StaticClass() 또는 StaticStruct()의 반환값
+ */
+template <typename T>
+requires
+    requires { T::StaticClass(); }
+    || requires { T::StaticStruct(); }
+[[nodiscard]] static UStruct* GetStructHelper()
+{
+    // UClass
+    if constexpr (requires { T::StaticClass(); })
+    {
+        return T::StaticClass();
+    }
+
+    // UScriptStruct
+    else if constexpr (requires { T::StaticStruct(); })
+    {
+        return T::StaticStruct();
+    }
+
+    else
+    {
+        // DECLARE_CLASS, DECLARE_STRUCT 없이 UPROPERTY만 선언한 경우
+        static_assert(TAlwaysFalse<T>, "T is neither UClass nor UScriptStruct");
+    }
+
+    std::unreachable();
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Struct.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Struct.h
@@ -12,7 +12,7 @@ class UStruct : public UObject
 {
 public:
     UStruct(
-        const FName& InName,
+        const char* InName,
         uint32 InStructSize,
         uint32 InAlignment,
         UStruct* InSuperStruct

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Struct.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Struct.h
@@ -1,0 +1,84 @@
+﻿#pragma once
+#include "UObject/Object.h"
+
+struct FProperty;
+
+
+/**
+ * UClass와 UScriptStruct의 기본 클래스입니다.
+ * 구조체 또는 클래스의 멤버 변수(프로퍼티) 목록, 크기, 정렬 등의 메타데이터를 관리합니다.
+ */
+class UStruct : public UObject
+{
+public:
+    UStruct(
+        const FName& InName,
+        uint32 InStructSize,
+        uint32 InAlignment,
+        UStruct* InSuperStruct
+    );
+
+    virtual ~UStruct() override;
+
+    UStruct(const UStruct&) = delete;
+    UStruct& operator=(const UStruct&) = delete;
+    UStruct(UStruct&&) = delete;
+    UStruct& operator=(UStruct&&) = delete;
+
+public:
+    [[nodiscard]] uint32 GetStructSize() const { return StructSize; }
+    [[nodiscard]] uint32 GetStructAlignment() const { return StructAlignment; }
+    [[nodiscard]] UStruct* GetSuperStruct() const { return SuperStruct; }
+
+    /** SomeBase의 자식 Struct인지 확인합니다. */
+    bool IsChildOf(const UStruct* SomeBase) const;
+
+    template <typename T>
+    requires
+        std::derived_from<T, UObject>
+    [[nodiscard]] bool IsChildOf() const;
+
+    [[nodiscard]] const TArray<FProperty*>& GetProperties() const { return Properties; }
+
+    /**
+     * UStruct에 Property를 추가합니다.
+     * @param Prop 추가할 Property
+     */
+    void AddProperty(FProperty* Prop);
+
+    /** 이름으로 Property를 찾습니다. 부모 Struct의 Property도 검색합니다. */
+    [[nodiscard]] FProperty* FindPropertyByName(const FName& InName) const;
+
+    /**
+     * 이 Struct 타입의 인스턴스 데이터를 직렬화합니다.
+     * @param Ar 직렬화 아카이브
+     * @param Data 직렬화할 Struct 데이터의 시작 포인터
+     */
+    virtual void SerializeBin(FArchive& Ar, void* Data);
+
+    /** 컴파일 타임에 알 수 없는 프로퍼티 타입을 런타임에 검사합니다.*/
+    static void ResolvePendingProperties();
+
+private:
+    /** 컴파일 타임에 알 수 없는 프로퍼티 목록들*/
+    static TArray<FProperty*>& GetUnresolvedProperties();
+
+protected:
+    uint32 StructSize;
+    uint32 StructAlignment;
+    UStruct* SuperStruct;
+
+    // 이 Struct/Class에 직접 정의된 프로퍼티들
+    TArray<FProperty*> Properties;
+
+    // 이름으로 프로퍼티를 빠르게 찾기 위한 맵
+    TMap<FName, FProperty*> PropertyMap;
+};
+
+template <typename T>
+requires
+    std::derived_from<T, UObject>
+bool UStruct::IsChildOf() const
+{
+    return IsChildOf(T::StaticClass());
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Struct.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Struct.h
@@ -25,9 +25,17 @@ public:
     UStruct(UStruct&&) = delete;
     UStruct& operator=(UStruct&&) = delete;
 
+    using Super = UObject;
+    using ThisClass = UStruct;
+
 public:
-    [[nodiscard]] uint32 GetStructSize() const { return StructSize; }
-    [[nodiscard]] uint32 GetStructAlignment() const { return StructAlignment; }
+    /** 현재 구조체의 Property 총 크기를 반환합니다. */
+    [[nodiscard]] uint32 GetPropertiesSize() const { return PropertiesSize; }
+
+    /** 현재 구조체의 최소 메모리 정렬 크기를 반환합니다. */
+    [[nodiscard]] uint32 GetMinAlignment() const { return MinAlignment; }
+
+    /** 부모의 UStruct를 가져옵니다. */
     [[nodiscard]] UStruct* GetSuperStruct() const { return SuperStruct; }
 
     /** SomeBase의 자식 Struct인지 확인합니다. */
@@ -64,8 +72,8 @@ private:
     static TArray<FProperty*>& GetUnresolvedProperties();
 
 protected:
-    uint32 StructSize;
-    uint32 StructAlignment;
+    uint32 PropertiesSize;
+    uint32 MinAlignment;
     UStruct* SuperStruct;
 
     // 이 Struct/Class에 직접 정의된 프로퍼티들

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Struct.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Struct.h
@@ -29,6 +29,9 @@ public:
     using ThisClass = UStruct;
 
 public:
+    /** 현재 구조체의 크기를 반환합니다. */
+    [[nodiscard]] uint32 GetStructSize() const { return StructSize; }
+
     /** 현재 구조체의 Property 총 크기를 반환합니다. */
     [[nodiscard]] uint32 GetPropertiesSize() const { return PropertiesSize; }
 
@@ -72,6 +75,7 @@ private:
     static TArray<FProperty*>& GetUnresolvedProperties();
 
 protected:
+    uint32 StructSize;
     uint32 PropertiesSize;
     uint32 MinAlignment;
     UStruct* SuperStruct;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/UObjectArray.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/UObjectArray.cpp
@@ -24,7 +24,7 @@ void FUObjectArray::ProcessPendingDestroyObjects()
     {
         const UClass* Class = Object->GetClass();
         std::string ObjectName = Object->GetName().ToAnsiString();
-        const uint32 ObjectSize = Class->GetClassSize();
+        const uint32 ObjectSize = Class->GetPropertiesSize();
 
         std::destroy_at(Object);
         FPlatformMemory::AlignedFree<EAT_Object>(Object, ObjectSize);

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/UObjectArray.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/UObjectArray.cpp
@@ -24,7 +24,7 @@ void FUObjectArray::ProcessPendingDestroyObjects()
     {
         const UClass* Class = Object->GetClass();
         std::string ObjectName = Object->GetName().ToAnsiString();
-        const uint32 ObjectSize = Class->GetPropertiesSize();
+        const uint32 ObjectSize = Class->GetStructSize();
 
         std::destroy_at(Object);
         FPlatformMemory::AlignedFree<EAT_Object>(Object, ObjectSize);

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/Engine.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/Engine.cpp
@@ -10,7 +10,7 @@ UEngine* GEngine = nullptr;
 void UEngine::Init()
 {
     // 컴파일 타임에 확정되지 못한 타입을 런타임에 검사
-    UClass::ResolvePendingProperties();
+    UStruct::ResolvePendingProperties();
 }
 
 FWorldContext* UEngine::GetWorldContextFromWorld(const UWorld* InWorld)

--- a/EngineSIU/EngineSIU/EngineSIU.vcxproj
+++ b/EngineSIU/EngineSIU/EngineSIU.vcxproj
@@ -238,6 +238,7 @@ xcopy /y /d "$(SolutionDir)$(ProjectName)\Engine\Source\ThirdParty\FBX\lib\x64\$
     <ClCompile Include="Engine\Source\Runtime\CoreUObject\UObject\ObjectUtils.cpp" />
     <ClCompile Include="Engine\Source\Runtime\CoreUObject\UObject\Property.cpp" />
     <ClCompile Include="Engine\Source\Runtime\CoreUObject\UObject\PropertyDisplay.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\CoreUObject\UObject\Struct.cpp" />
     <ClCompile Include="Engine\Source\Runtime\CoreUObject\UObject\UObjectArray.cpp" />
     <ClCompile Include="Engine\Source\Runtime\CoreUObject\UObject\UObjectHash.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Core\Container\String.cpp" />
@@ -535,6 +536,7 @@ xcopy /y /d "$(SolutionDir)$(ProjectName)\Engine\Source\ThirdParty\FBX\lib\x64\$
     <ClInclude Include="Engine\Source\Runtime\CoreUObject\UObject\ObjectUtils.h" />
     <ClInclude Include="Engine\Source\Runtime\CoreUObject\UObject\Property.h" />
     <ClInclude Include="Engine\Source\Runtime\CoreUObject\UObject\PropertyTypes.h" />
+    <ClInclude Include="Engine\Source\Runtime\CoreUObject\UObject\Struct.h" />
     <ClInclude Include="Engine\Source\Runtime\CoreUObject\UObject\UObjectArray.h" />
     <ClInclude Include="Engine\Source\Runtime\CoreUObject\UObject\UObjectHash.h" />
     <ClInclude Include="Engine\Source\Runtime\CoreUObject\UObject\UObjectIterator.h" />

--- a/EngineSIU/EngineSIU/EngineSIU.vcxproj
+++ b/EngineSIU/EngineSIU/EngineSIU.vcxproj
@@ -238,6 +238,7 @@ xcopy /y /d "$(SolutionDir)$(ProjectName)\Engine\Source\ThirdParty\FBX\lib\x64\$
     <ClCompile Include="Engine\Source\Runtime\CoreUObject\UObject\ObjectUtils.cpp" />
     <ClCompile Include="Engine\Source\Runtime\CoreUObject\UObject\Property.cpp" />
     <ClCompile Include="Engine\Source\Runtime\CoreUObject\UObject\PropertyDisplay.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\CoreUObject\UObject\ScriptStruct.cpp" />
     <ClCompile Include="Engine\Source\Runtime\CoreUObject\UObject\Struct.cpp" />
     <ClCompile Include="Engine\Source\Runtime\CoreUObject\UObject\UObjectArray.cpp" />
     <ClCompile Include="Engine\Source\Runtime\CoreUObject\UObject\UObjectHash.cpp" />
@@ -536,6 +537,7 @@ xcopy /y /d "$(SolutionDir)$(ProjectName)\Engine\Source\ThirdParty\FBX\lib\x64\$
     <ClInclude Include="Engine\Source\Runtime\CoreUObject\UObject\ObjectUtils.h" />
     <ClInclude Include="Engine\Source\Runtime\CoreUObject\UObject\Property.h" />
     <ClInclude Include="Engine\Source\Runtime\CoreUObject\UObject\PropertyTypes.h" />
+    <ClInclude Include="Engine\Source\Runtime\CoreUObject\UObject\ScriptStruct.h" />
     <ClInclude Include="Engine\Source\Runtime\CoreUObject\UObject\Struct.h" />
     <ClInclude Include="Engine\Source\Runtime\CoreUObject\UObject\UObjectArray.h" />
     <ClInclude Include="Engine\Source\Runtime\CoreUObject\UObject\UObjectHash.h" />


### PR DESCRIPTION
## 주요 변경사항
> 아래 내용은 AI가 요약하였습니다.
- `StructProperty`의 리플렉션 및 ImGui 데이터 표시 기능을 추가했습니다.
- 오브젝트 프로퍼티 처리 방식을 개선하여 부모 클래스의 속성까지 포함하도록 했습니다.
- `StructPointer` 타입의 새로운 생성 로직을 구현하고, UI 지원도 추가했습니다.
- 구조체 선언을 위한 매크로와 포인터용 커스텀 프로퍼티 검증 기능을 도입했습니다.
- 프로퍼티 클래스 구조를 리팩터링하고, 지원 타입을 확장했습니다(예: 대용량 데이터 처리를 위해 `int32`에서 `int64`로 변경).
- `UStruct` 구현을 업데이트하여 `UClass` 상속을 대체하고, 불필요한 메서드를 정리했습니다.
- 다양한 생성자, 매크로, 헬퍼 함수들을 일관성 있고 명확하게 개선했습니다.
- 타입 초기화 및 매크로 정의와 관련된 여러 버그를 수정했습니다.