### PR TITLE
Fix: 커스텀 구조체 Display로직 수정 및 상속관계 검증 추가

### DIFF
--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ObjectMacros.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ObjectMacros.h
@@ -2,6 +2,7 @@
 // ReSharper disable CppClangTidyClangDiagnosticPedantic
 // ReSharper disable CppClangTidyClangDiagnosticReservedMacroIdentifier
 #pragma once
+#include <concepts>
 #include "Class.h"
 #include "ScriptStruct.h"
 #include "UObjectHash.h"

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ObjectMacros.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ObjectMacros.h
@@ -84,6 +84,7 @@ public: \
     DECLARE_COMMON_STRUCT_BODY(TStruct, TSuperStruct) \
     static UScriptStruct* StaticStruct() \
     { \
+        static_assert(std::derived_from<TStruct, TSuperStruct>, INLINE_STRINGIFY(TStruct) " must inherit from " INLINE_STRINGIFY(TSuperStruct)); \
         static UScriptStruct StructInfo{ \
             INLINE_STRINGIFY(TStruct), \
             static_cast<uint32>(sizeof(TStruct)), \

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
@@ -515,7 +515,7 @@ void FStructProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* Dat
     {
         if (ImGui::TreeNodeEx(PropertyLabel, ImGuiTreeNodeFlags_Framed | ImGuiTreeNodeFlags_DefaultOpen))
         {
-            // TODO: Display 순서를 부모부터 띄우게 수정하기
+            // TODO: 나중에 Display 순서를 부모부터 띄우게 수정하기
             UStruct* CurrentStruct = *StructType;
             for (; CurrentStruct; CurrentStruct = CurrentStruct->GetSuperStruct())
             {

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
@@ -515,10 +515,15 @@ void FStructProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* Dat
     {
         if (ImGui::TreeNodeEx(PropertyLabel, ImGuiTreeNodeFlags_Framed | ImGuiTreeNodeFlags_DefaultOpen))
         {
-            for (const FProperty* Property : (*StructType)->GetProperties())
+            // TODO: Display 순서를 부모부터 띄우게 수정하기
+            UStruct* CurrentStruct = *StructType;
+            for (; CurrentStruct; CurrentStruct = CurrentStruct->GetSuperStruct())
             {
-                void* Data = static_cast<std::byte*>(DataPtr) + Property->Offset;
-                Property->DisplayRawDataInImGui(Property->Name, Data);
+                for (const FProperty* Property : CurrentStruct->GetProperties())
+                {
+                    void* Data = static_cast<std::byte*>(DataPtr) + Property->Offset;
+                    Property->DisplayRawDataInImGui(Property->Name, Data);
+                }
             }
             ImGui::TreePop();
         }


### PR DESCRIPTION
## 주요 변경사항
> 아래 내용은 AI가 요약하였습니다.
- 구조체를 상속할 때 부모 속성도 표시되도록 로직을 수정했습니다.
- TStruct와 TSuperStruct 간의 상속 관계를 검증하기 위해 static_assert를 추가했습니다.