### PR TITLE
Refactor and enhance property handling with added event logic

### DIFF
--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Object.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Object.cpp
@@ -35,6 +35,10 @@ UObject* UObject::Duplicate(UObject* InOuter)
     return FObjectFactory::ConstructObject(GetClass(), InOuter);
 }
 
+void UObject::PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent)
+{
+}
+
 void UObject::Serialize(FArchive& Ar)
 {
     // TODO: Serialize 구현

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Object.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Object.h
@@ -3,6 +3,7 @@
 #include "NameTypes.h"
 #include "Misc/CoreMiscDefines.h"
 
+struct FPropertyChangedEvent;
 extern FEngineLoop GEngineLoop;
 
 class UClass;
@@ -46,6 +47,12 @@ public:
     virtual ~UObject() = default;
 
     virtual UObject* Duplicate(UObject* InOuter);
+
+    /**
+     * 이 객체의 프로퍼티 중 하나가 에디터 등 외부 요인에 의해 변경된 후 호출됩니다.
+     * @param PropertyChangedEvent 변경된 프로퍼티에 대한 정보를 담고 있습니다.
+     */
+    virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent);
 
     UObject* GetOuter() const { return OuterPrivate; }
     virtual UWorld* GetWorld() const;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
@@ -2,9 +2,11 @@
 #include <variant>
 #include <optional>
 
+#include "PropertyEvent.h"
 #include "PropertyTypes.h"
 #include "Struct.h"
 #include "Container/Queue.h"
+#include "Misc/Optional.h"
 #include "Templates/TemplateUtilities.h"
 #include "Templates/TypeUtilities.h"
 
@@ -53,8 +55,9 @@ public:
      * ImGui를 통해 주어진 Raw Data를 표시합니다.
      * @param PropertyLabel 표시할 프로퍼티의 레이블
      * @param DataPtr 표시할 Raw Data의 포인터
+     * @param OwnerObject Data를 가지고 있는 Object
      */
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const;
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const;
 
     /** 런타임에 타입 정보를 검사하고 업데이트 합니다. */
     virtual void Resolve();
@@ -182,7 +185,7 @@ struct FInt8Property : public FNumericProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override;
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FInt16Property : public FNumericProperty
@@ -198,7 +201,7 @@ struct FInt16Property : public FNumericProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override;
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FInt32Property : public FNumericProperty
@@ -214,7 +217,7 @@ struct FInt32Property : public FNumericProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override;
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FInt64Property : public FNumericProperty
@@ -230,7 +233,7 @@ struct FInt64Property : public FNumericProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override;
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FUInt8Property : public FNumericProperty
@@ -246,7 +249,7 @@ struct FUInt8Property : public FNumericProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override;
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FUInt16Property : public FNumericProperty
@@ -262,7 +265,7 @@ struct FUInt16Property : public FNumericProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override;
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FUInt32Property : public FNumericProperty
@@ -278,7 +281,7 @@ struct FUInt32Property : public FNumericProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override;
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FUInt64Property : public FNumericProperty
@@ -294,7 +297,7 @@ struct FUInt64Property : public FNumericProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override;
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FFloatProperty : public FNumericProperty
@@ -310,7 +313,7 @@ struct FFloatProperty : public FNumericProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override;
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FDoubleProperty : public FNumericProperty
@@ -326,7 +329,7 @@ struct FDoubleProperty : public FNumericProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override;
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FBoolProperty : public FProperty
@@ -343,7 +346,7 @@ struct FBoolProperty : public FProperty
     }
 
     virtual void DisplayInImGui(UObject* Object) const override;
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override;
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FStrProperty : public FProperty
@@ -360,7 +363,7 @@ struct FStrProperty : public FProperty
     }
 
     virtual void DisplayInImGui(UObject* Object) const override;
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override;
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FNameProperty : public FProperty
@@ -375,7 +378,7 @@ struct FNameProperty : public FProperty
         : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Name, InSize, InOffset, InFlags)
     {}
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override;
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FVector2DProperty : public FProperty
@@ -392,7 +395,7 @@ struct FVector2DProperty : public FProperty
     }
 
     virtual void DisplayInImGui(UObject* Object) const override;
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override;
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FVectorProperty : public FProperty
@@ -409,7 +412,7 @@ struct FVectorProperty : public FProperty
     }
 
     virtual void DisplayInImGui(UObject* Object) const override;
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override;
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FVector4Property : public FProperty
@@ -426,7 +429,7 @@ struct FVector4Property : public FProperty
     }
 
     virtual void DisplayInImGui(UObject* Object) const override;
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override;
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FRotatorProperty : public FProperty
@@ -443,7 +446,7 @@ struct FRotatorProperty : public FProperty
     }
 
     virtual void DisplayInImGui(UObject* Object) const override;
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override;
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FQuatProperty : public FProperty
@@ -460,7 +463,7 @@ struct FQuatProperty : public FProperty
     }
 
     virtual void DisplayInImGui(UObject* Object) const override;
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override;
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FTransformProperty : public FProperty
@@ -476,7 +479,7 @@ struct FTransformProperty : public FProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override;
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FMatrixProperty : public FProperty
@@ -492,7 +495,7 @@ struct FMatrixProperty : public FProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override;
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FColorProperty : public FProperty
@@ -509,7 +512,7 @@ struct FColorProperty : public FProperty
     }
 
     virtual void DisplayInImGui(UObject* Object) const override;
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override;
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FLinearColorProperty : public FProperty
@@ -526,7 +529,7 @@ struct FLinearColorProperty : public FProperty
     }
 
     virtual void DisplayInImGui(UObject* Object) const override;
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override;
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 template <typename InArrayType>
@@ -547,9 +550,9 @@ struct TArrayProperty : public FProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override
     {
-        FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
+        FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
 
         enum class EArrayElementOption : uint8
         {
@@ -562,6 +565,7 @@ struct TArrayProperty : public FProperty
         {
             ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));
             {
+                TOptional<FPropertyChangedEvent> Event;
                 TArray<ElementType>* Data = static_cast<TArray<ElementType>*>(DataPtr);
 
                 const ImGuiIO& IO = ImGui::GetIO();
@@ -574,6 +578,7 @@ struct TArrayProperty : public FProperty
                 if (ImGui::Button("\ue9c8"))
                 {
                     Data->AddDefaulted();
+                    Event = FPropertyChangedEvent{const_cast<TArrayProperty*>(this), OwnerObject, EPropertyChangeType::ArrayAdd};
                 }
                 ImGui::PopFont();
                 ImGui::SetItemTooltip("Add Element");
@@ -583,6 +588,7 @@ struct TArrayProperty : public FProperty
                 if (ImGui::Button("\ue9f6"))
                 {
                     Data->Empty();
+                    Event = FPropertyChangedEvent{const_cast<TArrayProperty*>(this), OwnerObject, EPropertyChangeType::ArrayClear};
                 }
                 ImGui::PopFont();
                 ImGui::SetItemTooltip("Remove All Elements");
@@ -590,7 +596,7 @@ struct TArrayProperty : public FProperty
                 TQueue<TPair<EArrayElementOption, int32>> OptionQueue;
                 for (int32 Index = 0; Index < Data->Num(); ++Index)
                 {
-                    ElementProperty->DisplayRawDataInImGui(std::format("Idx [{}]", Index).c_str(), &((*Data)[Index]));
+                    ElementProperty->DisplayRawDataInImGui(std::format("Idx [{}]", Index).c_str(), &((*Data)[Index]), OwnerObject);
 
                     std::string PopupLabel = std::format("ArrayElementOption##{}", Index);
                     ImGui::SameLine();
@@ -604,14 +610,17 @@ struct TArrayProperty : public FProperty
                         if (ImGui::Selectable("Insert"))
                         {
                             OptionQueue.Enqueue(MakePair(EArrayElementOption::Insert, Index));
+                            Event = FPropertyChangedEvent{const_cast<TArrayProperty*>(this), OwnerObject, EPropertyChangeType::ArrayAdd};
                         }
                         else if (ImGui::Selectable("Remove"))
                         {
                             OptionQueue.Enqueue(MakePair(EArrayElementOption::Remove, Index));
+                            Event = FPropertyChangedEvent{const_cast<TArrayProperty*>(this), OwnerObject, EPropertyChangeType::ArrayRemove};
                         }
                         else if (ImGui::Selectable("Duplicate"))
                         {
                             OptionQueue.Enqueue(MakePair(EArrayElementOption::Duplicate, Index));
+                            Event = FPropertyChangedEvent{const_cast<TArrayProperty*>(this), OwnerObject, EPropertyChangeType::ArrayAdd};
                         }
                         ImGui::EndPopup();
                     }
@@ -640,6 +649,11 @@ struct TArrayProperty : public FProperty
                         break;
                     }
                 }
+
+                if (Event)
+                {
+                    OwnerObject->PostEditChangeProperty(*Event);
+                }
             }
             ImGui::EndDisabled();
             ImGui::TreePop();
@@ -667,9 +681,9 @@ struct TMapProperty : public FProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override
     {
-        FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
+        FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
 
         enum class EMapElementOption : uint8
         {
@@ -682,6 +696,9 @@ struct TMapProperty : public FProperty
         {
             ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));
             {
+                // TODO: 나중에 추가
+                [[maybe_unused]] TOptional<FPropertyChangedEvent> Event;
+
                 const ImGuiIO& IO = ImGui::GetIO();
                 ImFont* IconFont = IO.Fonts->Fonts[1]; // FEATHER_FONT = 1
 
@@ -760,7 +777,7 @@ struct TMapProperty : public FProperty
                         if (ImGui::TreeNode(std::format("Key ({})", KeyTypeName).c_str()))
                         {
                             // TODO: 겹치는 Key에 대해서는 나중에 수정해야함
-                            KeyProperty->DisplayRawDataInImGui("", &const_cast<KeyType&>(Pair.Key));
+                            KeyProperty->DisplayRawDataInImGui("", &const_cast<KeyType&>(Pair.Key), OwnerObject);
                             ImGui::TreePop();
                         }
 
@@ -768,7 +785,7 @@ struct TMapProperty : public FProperty
                         std::string ValueTypeName = std::string(ValueTypeNameView);
                         if (ImGui::TreeNode(std::format("Value ({})", ValueTypeName).c_str()))
                         {
-                            ValueProperty->DisplayRawDataInImGui("##Value", &Pair.Value);
+                            ValueProperty->DisplayRawDataInImGui("##Value", &Pair.Value, OwnerObject);
                             ImGui::TreePop();
                         }
 
@@ -818,9 +835,9 @@ struct TSetProperty : public FProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override
     {
-        FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
+        FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
 
         enum class ESetElementOption : uint8
         {
@@ -833,6 +850,9 @@ struct TSetProperty : public FProperty
         {
             ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));
             {
+                // TODO: 나중에 추가
+                [[maybe_unused]] TOptional<FPropertyChangedEvent> Event;
+
                 const ImGuiIO& IO = ImGui::GetIO();
                 ImFont* IconFont = IO.Fonts->Fonts[1]; // FEATHER_FONT = 1
     
@@ -883,7 +903,7 @@ struct TSetProperty : public FProperty
                     ImGui::PushID(&Element);
 
                     // TODO: 겹치는 Key에 대해서는 나중에 수정해야함
-                    ElementProperty->DisplayRawDataInImGui(std::format("Elem [{}]", Idx).c_str(), &const_cast<ElementType&>(Element));
+                    ElementProperty->DisplayRawDataInImGui(std::format("Elem [{}]", Idx).c_str(), &const_cast<ElementType&>(Element), OwnerObject);
 
                     std::string PopupLabel = std::format("SetElementOption##{}", Idx);
                     ImGui::SameLine();
@@ -951,9 +971,9 @@ struct TEnumProperty : public FProperty
         ImGui::EndDisabled();
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override
     {
-        FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
+        FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
 
         EnumType* Data = static_cast<EnumType*>(DataPtr);
         constexpr auto EnumEntries = magic_enum::enum_entries<EnumType>();
@@ -972,6 +992,11 @@ struct TEnumProperty : public FProperty
                 if (ImGui::Selectable(EnumName.c_str(), bIsSelected))
                 {
                     *Data = Enum;
+                    if (IsValid(OwnerObject))
+                    {
+                        FPropertyChangedEvent Event{const_cast<TEnumProperty*>(this), OwnerObject, EPropertyChangeType::ValueSet};
+                        OwnerObject->PostEditChangeProperty(Event);
+                    }
                 }
                 if (bIsSelected)
                 {
@@ -997,7 +1022,7 @@ struct FSubclassOfProperty : public FProperty
     }
 
     virtual void DisplayInImGui(UObject* Object) const override;
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override;
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FObjectProperty : public FProperty
@@ -1013,7 +1038,7 @@ struct FObjectProperty : public FProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override;
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FStructProperty : public FProperty
@@ -1029,7 +1054,7 @@ struct FStructProperty : public FProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const override;
+    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FUnresolvedPtrProperty : public FProperty

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
@@ -1,6 +1,7 @@
 ﻿#include "Property.h"
 
 #include "Class.h"
+#include "PropertyEvent.h"
 #include "ScriptStruct.h"
 #include "UObjectHash.h"
 #include "Editor/UnrealEd/ImGuiWidget.h"
@@ -8,6 +9,7 @@
 #include "Template/SubclassOf.h"
 
 #include "ImGui/imgui.h"
+#include "Misc/Optional.h"
 
 template <typename Type, typename... Types>
 concept TIsAnyOf = (std::same_as<Type, Types> || ...);
@@ -21,7 +23,9 @@ static constexpr int32 IMGUI_FSTRING_BUFFER_SIZE = 2048;
 struct FPropertyUIHelper
 {
     template <NumericType NumType>
-    static void DisplayNumericDragN(const char* PropertyLabel, void* InData, int Components, float Speed = 1.0f, const char* Format = nullptr)
+    static TOptional<EPropertyChangeType> DisplayNumericDragN(
+        const char* PropertyLabel, void* InData, int Components, float Speed = 1.0f, const char* Format = nullptr
+    )
     {
         NumType* Data = static_cast<NumType*>(InData);
         constexpr NumType Min = TNumericLimits<NumType>::Lowest();
@@ -42,7 +46,20 @@ struct FPropertyUIHelper
 
         ImGui::Text("%s", PropertyLabel);
         ImGui::SameLine();
-        ImGui::DragScalarN(std::format("##{}", PropertyLabel).c_str(), DataType, Data, Components, Speed, &Min, &Max, Format);
+        const std::string FormatStr = std::format("##{}", PropertyLabel);
+        const bool bIsInteractive = ImGui::DragScalarN(FormatStr.c_str(), DataType, Data, Components, Speed, &Min, &Max, Format);
+
+        if (ImGui::IsItemDeactivatedAfterEdit())
+        {
+            return EPropertyChangeType::ValueSet;
+        }
+
+        if (bIsInteractive)
+        {
+            return EPropertyChangeType::Interactive;
+        }
+
+        return {};
     }
 };
 
@@ -55,10 +72,10 @@ void FProperty::DisplayInImGui(UObject* Object) const
     }
 
     void* Data = GetPropertyData(Object);
-    DisplayRawDataInImGui(Name, Data);
+    DisplayRawDataInImGui(Name, Data, Object);
 }
 
-void FProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const
+void FProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
 }
 
@@ -71,74 +88,114 @@ void FNumericProperty::DisplayInImGui(UObject* Object) const
     ImGui::EndDisabled();
 }
 
-void FInt8Property::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const
+void FInt8Property::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FNumericProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
+    FNumericProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
 
-    FPropertyUIHelper::DisplayNumericDragN<int8>(PropertyLabel, DataPtr, 1);
+    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<int8>(PropertyLabel, DataPtr, 1);
+    if (!ChangeResult.IsSet()) return;
+
+    FPropertyChangedEvent Event{const_cast<FInt8Property*>(this), OwnerObject, *ChangeResult};
+    OwnerObject->PostEditChangeProperty(Event);
 }
 
-void FInt16Property::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const
+void FInt16Property::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FNumericProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
+    FNumericProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
 
-    FPropertyUIHelper::DisplayNumericDragN<int16>(PropertyLabel, DataPtr, 1);
+    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<int16>(PropertyLabel, DataPtr, 1);
+    if (!ChangeResult.IsSet()) return;
+
+    FPropertyChangedEvent Event{const_cast<FInt16Property*>(this), OwnerObject, *ChangeResult};
+    OwnerObject->PostEditChangeProperty(Event);
 }
 
-void FInt32Property::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const
+void FInt32Property::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FNumericProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
+    FNumericProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
 
-    FPropertyUIHelper::DisplayNumericDragN<int32>(PropertyLabel, DataPtr, 1);
+    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<int32>(PropertyLabel, DataPtr, 1);
+    if (!ChangeResult.IsSet()) return;
+
+    FPropertyChangedEvent Event{const_cast<FInt32Property*>(this), OwnerObject, *ChangeResult};
+    OwnerObject->PostEditChangeProperty(Event);
 }
 
-void FInt64Property::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const
+void FInt64Property::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FNumericProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
+    FNumericProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
 
-    FPropertyUIHelper::DisplayNumericDragN<int64>(PropertyLabel, DataPtr, 1);
+    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<int64>(PropertyLabel, DataPtr, 1);
+    if (!ChangeResult.IsSet()) return;
+
+    FPropertyChangedEvent Event{const_cast<FInt64Property*>(this), OwnerObject, *ChangeResult};
+    OwnerObject->PostEditChangeProperty(Event);
 }
 
-void FUInt8Property::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const
+void FUInt8Property::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FNumericProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
+    FNumericProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
 
-    FPropertyUIHelper::DisplayNumericDragN<uint8>(PropertyLabel, DataPtr, 1);
+    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<uint8>(PropertyLabel, DataPtr, 1);
+    if (!ChangeResult.IsSet()) return;
+
+    FPropertyChangedEvent Event{const_cast<FUInt8Property*>(this), OwnerObject, *ChangeResult};
+    OwnerObject->PostEditChangeProperty(Event);
 }
 
-void FUInt16Property::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const
+void FUInt16Property::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FNumericProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
+    FNumericProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
 
-    FPropertyUIHelper::DisplayNumericDragN<uint16>(PropertyLabel, DataPtr, 1);
+    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<uint16>(PropertyLabel, DataPtr, 1);
+    if (!ChangeResult.IsSet()) return;
+
+    FPropertyChangedEvent Event{const_cast<FUInt16Property*>(this), OwnerObject, *ChangeResult};
+    OwnerObject->PostEditChangeProperty(Event);
 }
 
-void FUInt32Property::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const
+void FUInt32Property::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FNumericProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
+    FNumericProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
 
-    FPropertyUIHelper::DisplayNumericDragN<uint32>(PropertyLabel, DataPtr, 1);
+    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<uint32>(PropertyLabel, DataPtr, 1);
+    if (!ChangeResult.IsSet()) return;
+
+    FPropertyChangedEvent Event{const_cast<FUInt32Property*>(this), OwnerObject, *ChangeResult};
+    OwnerObject->PostEditChangeProperty(Event);
 }
 
-void FUInt64Property::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const
+void FUInt64Property::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FNumericProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
+    FNumericProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
 
-    FPropertyUIHelper::DisplayNumericDragN<uint64>(PropertyLabel, DataPtr, 1);
+    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<uint64>(PropertyLabel, DataPtr, 1);
+    if (!ChangeResult.IsSet()) return;
+
+    FPropertyChangedEvent Event{const_cast<FUInt64Property*>(this), OwnerObject, *ChangeResult};
+    OwnerObject->PostEditChangeProperty(Event);
 }
 
-void FFloatProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const
+void FFloatProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FNumericProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
+    FNumericProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
 
-    FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 1);
+    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 1);
+    if (!ChangeResult.IsSet()) return;
+
+    FPropertyChangedEvent Event{const_cast<FFloatProperty*>(this), OwnerObject, *ChangeResult};
+    OwnerObject->PostEditChangeProperty(Event);
 }
 
-void FDoubleProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const
+void FDoubleProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FNumericProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
+    FNumericProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
 
-    FPropertyUIHelper::DisplayNumericDragN<double>(PropertyLabel, DataPtr, 1);
+    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<double>(PropertyLabel, DataPtr, 1);
+    if (!ChangeResult.IsSet()) return;
+
+    FPropertyChangedEvent Event{const_cast<FDoubleProperty*>(this), OwnerObject, *ChangeResult};
+    OwnerObject->PostEditChangeProperty(Event);
 }
 
 void FBoolProperty::DisplayInImGui(UObject* Object) const
@@ -150,11 +207,18 @@ void FBoolProperty::DisplayInImGui(UObject* Object) const
     ImGui::EndDisabled();
 }
 
-void FBoolProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const
+void FBoolProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
+    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
 
-    ImGui::Checkbox(PropertyLabel, static_cast<bool*>(DataPtr));
+    if (ImGui::Checkbox(PropertyLabel, static_cast<bool*>(DataPtr)))
+    {
+        if (IsValid(OwnerObject))
+        {
+            FPropertyChangedEvent Event{const_cast<FBoolProperty*>(this), OwnerObject, EPropertyChangeType::ValueSet};
+            OwnerObject->PostEditChangeProperty(Event);
+        }
+    }
 }
 
 void FStrProperty::DisplayInImGui(UObject* Object) const
@@ -166,9 +230,9 @@ void FStrProperty::DisplayInImGui(UObject* Object) const
     ImGui::EndDisabled();
 }
 
-void FStrProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const
+void FStrProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
+    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
 
     FString* Data = static_cast<FString*>(DataPtr);
 
@@ -176,17 +240,39 @@ void FStrProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPt
     FCStringAnsi::Strncpy(Buffer, Data->ToAnsiString().c_str(), IMGUI_FSTRING_BUFFER_SIZE);
     Buffer[IMGUI_FSTRING_BUFFER_SIZE - 1] = '\0'; // 항상 널 종료 보장
 
+    bool bChanged = false;
+
     ImGui::Text("%s", PropertyLabel);
     ImGui::SameLine();
-    if (ImGui::InputText(std::format("##{}", PropertyLabel).c_str(), Buffer, IMGUI_FSTRING_BUFFER_SIZE))
+    if (ImGui::InputText(std::format("##{}", PropertyLabel).c_str(), Buffer, IMGUI_FSTRING_BUFFER_SIZE, ImGuiInputTextFlags_EnterReturnsTrue))
     {
-        *Data = Buffer;
+        bChanged = true;
+    }
+
+    if (ImGui::IsItemDeactivatedAfterEdit()) // 포커스 아웃 등으로 편집 완료
+    {
+        // InputText 내부에서 이미 Buffer가 변경되었을 수 있음
+        // 실제 Data와 Buffer를 비교하여 변경되었는지 확인 후 bChanged 설정 가능
+        if (*Data != Buffer)
+        {
+            bChanged = true;
+        }
+    }
+
+    if (bChanged)
+    {
+        *Data = Buffer; // 실제 데이터 업데이트
+        if (IsValid(OwnerObject))
+        {
+            FPropertyChangedEvent Event(const_cast<FStrProperty*>(this), OwnerObject, EPropertyChangeType::ValueSet); // ValueSet으로 명시
+            OwnerObject->PostEditChangeProperty(Event);
+        }
     }
 }
 
-void FNameProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const
+void FNameProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
+    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
 
     const FName* Data = static_cast<FName*>(DataPtr);
     std::string NameStr = Data->ToString().ToAnsiString();
@@ -210,11 +296,15 @@ void FVector2DProperty::DisplayInImGui(UObject* Object) const
     ImGui::EndDisabled();
 }
 
-void FVector2DProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const
+void FVector2DProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
+    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
 
-    FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 2);
+    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 2);
+    if (!ChangeResult.IsSet()) return;
+
+    FPropertyChangedEvent Event{const_cast<FVector2DProperty*>(this), OwnerObject, *ChangeResult};
+    OwnerObject->PostEditChangeProperty(Event);
 }
 
 void FVectorProperty::DisplayInImGui(UObject* Object) const
@@ -226,11 +316,15 @@ void FVectorProperty::DisplayInImGui(UObject* Object) const
     ImGui::EndDisabled();
 }
 
-void FVectorProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const
+void FVectorProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
+    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
 
-    FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 3);
+    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 3);
+    if (!ChangeResult.IsSet()) return;
+
+    FPropertyChangedEvent Event{const_cast<FVectorProperty*>(this), OwnerObject, *ChangeResult};
+    OwnerObject->PostEditChangeProperty(Event);
 }
 
 void FVector4Property::DisplayInImGui(UObject* Object) const
@@ -242,11 +336,15 @@ void FVector4Property::DisplayInImGui(UObject* Object) const
     ImGui::EndDisabled();
 }
 
-void FVector4Property::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const
+void FVector4Property::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
+    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
 
-    FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 4);
+    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 4);
+    if (!ChangeResult.IsSet()) return;
+
+    FPropertyChangedEvent Event{const_cast<FVector4Property*>(this), OwnerObject, *ChangeResult};
+    OwnerObject->PostEditChangeProperty(Event);
 }
 
 void FRotatorProperty::DisplayInImGui(UObject* Object) const
@@ -258,11 +356,15 @@ void FRotatorProperty::DisplayInImGui(UObject* Object) const
     ImGui::EndDisabled();
 }
 
-void FRotatorProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const
+void FRotatorProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
+    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
 
-    FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 3);
+    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 3);
+    if (!ChangeResult.IsSet()) return;
+
+    FPropertyChangedEvent Event{const_cast<FRotatorProperty*>(this), OwnerObject, *ChangeResult};
+    OwnerObject->PostEditChangeProperty(Event);
 }
 
 void FQuatProperty::DisplayInImGui(UObject* Object) const
@@ -274,16 +376,20 @@ void FQuatProperty::DisplayInImGui(UObject* Object) const
     ImGui::EndDisabled();
 }
 
-void FQuatProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const
+void FQuatProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
+    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
 
-    FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 4);
+    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 4);
+    if (!ChangeResult.IsSet()) return;
+
+    FPropertyChangedEvent Event{const_cast<FQuatProperty*>(this), OwnerObject, *ChangeResult};
+    OwnerObject->PostEditChangeProperty(Event);
 }
 
-void FTransformProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const
+void FTransformProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
+    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
 
     if (ImGui::TreeNode(PropertyLabel))
     {
@@ -292,25 +398,34 @@ void FTransformProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* 
             FTransform* Data = static_cast<FTransform*>(DataPtr);
             FRotator Rotation = Data->Rotator();
 
-            FImGuiWidget::DrawVec3Control("Location", Data->Translation);
-            FImGuiWidget::DrawRot3Control("Rotation", Rotation);
-            FImGuiWidget::DrawVec3Control("Scale", Data->Scale3D, 1.0f);
+            bool bChangedThisFrame = false;
+            bChangedThisFrame |= FImGuiWidget::DrawVec3Control("Location", Data->Translation);
+            bChangedThisFrame |= FImGuiWidget::DrawRot3Control("Rotation", Rotation);
+            bChangedThisFrame |= FImGuiWidget::DrawVec3Control("Scale", Data->Scale3D, 1.0f);
 
-            Data->Rotation = Rotation.Quaternion();
+            if (bChangedThisFrame)
+            {
+                Data->Rotation = Rotation.Quaternion();
+
+                if (IsValid(OwnerObject))
+                {
+                    FPropertyChangedEvent Event{const_cast<FTransformProperty*>(this), OwnerObject};
+                    OwnerObject->PostEditChangeProperty(Event);
+                }
+            }
         }
         ImGui::EndDisabled();
         ImGui::TreePop();
     }
 }
 
-void FMatrixProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const
+void FMatrixProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
+    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
 
     // TODO: 짐벌락 현상 있음
     if (ImGui::TreeNode(PropertyLabel))
     {
-        bool bChanged = false;
         FMatrix* Data = static_cast<FMatrix*>(DataPtr);
 
         ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));
@@ -318,6 +433,7 @@ void FMatrixProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* Dat
             FTransform Transform = FTransform(*Data);
             FRotator Rotation = Transform.Rotator();
 
+            bool bChanged = false;
             bChanged |= FImGuiWidget::DrawVec3Control("Location", Transform.Translation);
             bChanged |= FImGuiWidget::DrawRot3Control("Rotation", Rotation);
             bChanged |= FImGuiWidget::DrawVec3Control("Scale", Transform.Scale3D, 1.0f);
@@ -328,6 +444,12 @@ void FMatrixProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* Dat
                     FMatrix::CreateScaleMatrix(Transform.Scale3D)
                     * FMatrix::CreateRotationMatrix(Rotation.Quaternion())
                     * FMatrix::CreateTranslationMatrix(Transform.Translation);
+
+                if (IsValid(OwnerObject))
+                {
+                    FPropertyChangedEvent Event{const_cast<FMatrixProperty*>(this), OwnerObject};
+                    OwnerObject->PostEditChangeProperty(Event);
+                }
             }
         }
         ImGui::EndDisabled();
@@ -336,10 +458,17 @@ void FMatrixProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* Dat
         {
             ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));
             {
-                ImGui::DragFloat4("##1", Data->M[0], 0.01f, -FLT_MAX, FLT_MAX, "%.3f");
-                ImGui::DragFloat4("##2", Data->M[1], 0.01f, -FLT_MAX, FLT_MAX, "%.3f");
-                ImGui::DragFloat4("##3", Data->M[2], 0.01f, -FLT_MAX, FLT_MAX, "%.3f");
-                ImGui::DragFloat4("##4", Data->M[3], 0.01f, -FLT_MAX, FLT_MAX, "%.3f");
+                bool bChanged = false;
+                bChanged |= ImGui::DragFloat4("##1", Data->M[0], 0.01f, -FLT_MAX, FLT_MAX, "%.3f");
+                bChanged |= ImGui::DragFloat4("##2", Data->M[1], 0.01f, -FLT_MAX, FLT_MAX, "%.3f");
+                bChanged |= ImGui::DragFloat4("##3", Data->M[2], 0.01f, -FLT_MAX, FLT_MAX, "%.3f");
+                bChanged |= ImGui::DragFloat4("##4", Data->M[3], 0.01f, -FLT_MAX, FLT_MAX, "%.3f");
+
+                if (bChanged && IsValid(OwnerObject))
+                {
+                    FPropertyChangedEvent Event{const_cast<FMatrixProperty*>(this), OwnerObject};
+                    OwnerObject->PostEditChangeProperty(Event);
+                }
             }
             ImGui::EndDisabled();
             ImGui::TreePop();
@@ -358,12 +487,12 @@ void FColorProperty::DisplayInImGui(UObject* Object) const
     ImGui::EndDisabled();
 }
 
-void FColorProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const
+void FColorProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
+    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
 
     FColor* Data = static_cast<FColor*>(DataPtr);
-    FLinearColor LinearColor = FLinearColor(*Data);
+    FLinearColor LinearColorForUI = FLinearColor(*Data);
 
     constexpr ImGuiColorEditFlags Flags =
         ImGuiColorEditFlags_DisplayRGB
@@ -373,10 +502,16 @@ void FColorProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* Data
 
     ImGui::Text("%s", PropertyLabel);
     ImGui::SameLine();
-    if (ImGui::ColorEdit4(std::format("##{}", PropertyLabel).c_str(), reinterpret_cast<float*>(&LinearColor), Flags))
+    if (ImGui::ColorEdit4(std::format("##{}", PropertyLabel).c_str(), reinterpret_cast<float*>(&LinearColorForUI), Flags))
     {
-        *Data = LinearColor.ToColorRawRGB8();
+        *Data = LinearColorForUI.ToColorRawRGB8();
+        if (OwnerObject)
+        {
+            FPropertyChangedEvent Event(const_cast<FColorProperty*>(this), OwnerObject, EPropertyChangeType::ValueSet);
+            OwnerObject->PostEditChangeProperty(Event);
+        }
     }
+
 }
 
 void FLinearColorProperty::DisplayInImGui(UObject* Object) const
@@ -388,9 +523,9 @@ void FLinearColorProperty::DisplayInImGui(UObject* Object) const
     ImGui::EndDisabled();
 }
 
-void FLinearColorProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const
+void FLinearColorProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
+    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
 
     FLinearColor* Data = static_cast<FLinearColor*>(DataPtr);
 
@@ -402,7 +537,14 @@ void FLinearColorProperty::DisplayRawDataInImGui(const char* PropertyLabel, void
 
     ImGui::Text("%s", PropertyLabel);
     ImGui::SameLine();
-    ImGui::ColorEdit4(std::format("##{}", PropertyLabel).c_str(), reinterpret_cast<float*>(Data), Flags);
+    if (ImGui::ColorEdit4(std::format("##{}", PropertyLabel).c_str(), reinterpret_cast<float*>(Data), Flags))
+    {
+        if (OwnerObject)
+        {
+            FPropertyChangedEvent Event(const_cast<FLinearColorProperty*>(this), OwnerObject, EPropertyChangeType::ValueSet);
+            OwnerObject->PostEditChangeProperty(Event);
+        }
+    }
 }
 
 void FSubclassOfProperty::DisplayInImGui(UObject* Object) const
@@ -414,9 +556,9 @@ void FSubclassOfProperty::DisplayInImGui(UObject* Object) const
     ImGui::EndDisabled();
 }
 
-void FSubclassOfProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const
+void FSubclassOfProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
+    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
 
     TSubclassOf<UObject>* Data = static_cast<TSubclassOf<UObject>*>(DataPtr);
     UClass* CurrentClass = GetSpecificClass();
@@ -428,6 +570,7 @@ void FSubclassOfProperty::DisplayRawDataInImGui(const char* PropertyLabel, void*
     TArray<UClass*> ChildClasses;
     GetChildOfClass(CurrentClass, ChildClasses);
 
+    bool bChanged = false;
     const std::string CurrentClassName = (*Data) ? (*Data)->GetName().ToAnsiString() : "None";
     ImGui::Text("%s", PropertyLabel);
     ImGui::SameLine();
@@ -436,6 +579,7 @@ void FSubclassOfProperty::DisplayRawDataInImGui(const char* PropertyLabel, void*
         if (ImGui::Selectable("None", !(*Data)))
         {
             *Data = nullptr;
+            bChanged = true;
         }
 
         for (UClass* ChildClass : ChildClasses)
@@ -445,6 +589,7 @@ void FSubclassOfProperty::DisplayRawDataInImGui(const char* PropertyLabel, void*
             if (ImGui::Selectable(ChildClassName.c_str(), bIsSelected))
             {
                 *Data = ChildClass;
+                bChanged = true;
             }
             if (bIsSelected)
             {
@@ -453,11 +598,20 @@ void FSubclassOfProperty::DisplayRawDataInImGui(const char* PropertyLabel, void*
         }
         ImGui::EndCombo();
     }
+
+    if (bChanged)
+    {
+        if (IsValid(OwnerObject))
+        {
+            FPropertyChangedEvent Event(const_cast<FSubclassOfProperty*>(this), OwnerObject, EPropertyChangeType::ValueSet);
+            OwnerObject->PostEditChangeProperty(Event);
+        }
+    }
 }
 
-void FObjectProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const
+void FObjectProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
+    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
 
     if (ImGui::TreeNodeEx(PropertyLabel, ImGuiTreeNodeFlags_Framed | ImGuiTreeNodeFlags_DefaultOpen))
     {
@@ -479,8 +633,10 @@ void FObjectProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* Dat
                         const bool bIsSelected = ChildObject == *Object;
                         if (ImGui::Selectable(ObjectName.c_str(), bIsSelected))
                         {
-                            // TODO: 나중에 수정, 지금은 목록만 보여주고, 설정은 안함
+                            // OwnerObject: 나중에 수정, 지금은 목록만 보여주고, 설정은 안함
                             *Object = ChildObject;
+                            FPropertyChangedEvent Event(const_cast<FObjectProperty*>(this), OwnerObject, EPropertyChangeType::ValueSet);
+                            OwnerObject->PostEditChangeProperty(Event);
                         }
                         if (bIsSelected)
                         {
@@ -507,9 +663,9 @@ void FObjectProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* Dat
     }
 }
 
-void FStructProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr) const
+void FStructProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr);
+    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
 
     if (UScriptStruct* const* StructType = std::get_if<UScriptStruct*>(&TypeSpecificData))
     {
@@ -522,7 +678,7 @@ void FStructProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* Dat
                 for (const FProperty* Property : CurrentStruct->GetProperties())
                 {
                     void* Data = static_cast<std::byte*>(DataPtr) + Property->Offset;
-                    Property->DisplayRawDataInImGui(Property->Name, Data);
+                    Property->DisplayRawDataInImGui(Property->Name, Data, OwnerObject);
                 }
             }
             ImGui::TreePop();

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyEvent.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyEvent.h
@@ -20,7 +20,7 @@ struct FPropertyChangedEvent
     FProperty* Property = nullptr;
 
     // 만약 Property가 구조체나 배열이고, 그 내부 멤버가 변경된 경우 해당 멤버 FProperty
-    FProperty* MemberProperty = nullptr;
+    // FProperty* MemberProperty = nullptr;
 
     // (예: Transform.Location.X -> Property는 Transform, MemberProperty는 Location의 X)
     // (구현 복잡도에 따라 이 부분은 단순화하거나 확장 가능)
@@ -30,7 +30,7 @@ struct FPropertyChangedEvent
 
     EPropertyChangeType ChangeType = EPropertyChangeType::ValueSet;
 
-    int32 ArrayIndices[2] = {-1, -1}; // 배열 변경 시 인덱스 정보 (예: 추가된 위치, 삭제된 위치 범위)
+    // int32 ArrayIndices[2] = {-1, -1}; // 배열 변경 시 인덱스 정보 (예: 추가된 위치, 삭제된 위치 범위)
 
 public:
     FPropertyChangedEvent(FProperty* InProperty, UObject* InObjectThatChanged, EPropertyChangeType InChangeType = EPropertyChangeType::ValueSet)

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyEvent.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyEvent.h
@@ -1,0 +1,42 @@
+﻿#pragma once
+#include "HAL/PlatformType.h"
+
+class UObject;
+struct FProperty;
+
+
+enum class EPropertyChangeType : uint8
+{
+    Interactive, // 사용자가 드래그하는 등 실시간으로 여러 번 발생 가능
+    ValueSet,    // 최종적으로 값이 설정되었을 때 (예: 입력 필드에서 Enter, 드래그 완료)
+    ArrayAdd,    // 배열에 요소 추가
+    ArrayRemove, // 배열에서 요소 제거
+    ArrayClear,  // 배열 비우기
+};
+
+struct FPropertyChangedEvent
+{
+    // 변경된 프로퍼티의 FProperty 객체 (가장 직접적인 변경)
+    FProperty* Property = nullptr;
+
+    // 만약 Property가 구조체나 배열이고, 그 내부 멤버가 변경된 경우 해당 멤버 FProperty
+    FProperty* MemberProperty = nullptr;
+
+    // (예: Transform.Location.X -> Property는 Transform, MemberProperty는 Location의 X)
+    // (구현 복잡도에 따라 이 부분은 단순화하거나 확장 가능)
+
+    // 프로퍼티 변경이 발생한 최상위 UObject
+    UObject* ObjectThatChanged = nullptr;
+
+    EPropertyChangeType ChangeType = EPropertyChangeType::ValueSet;
+
+    int32 ArrayIndices[2] = {-1, -1}; // 배열 변경 시 인덱스 정보 (예: 추가된 위치, 삭제된 위치 범위)
+
+public:
+    FPropertyChangedEvent(FProperty* InProperty, UObject* InObjectThatChanged, EPropertyChangeType InChangeType = EPropertyChangeType::ValueSet)
+        : Property(InProperty)
+        , ObjectThatChanged(InObjectThatChanged)
+        , ChangeType(InChangeType)
+    {
+    }
+};

--- a/EngineSIU/EngineSIU/EngineSIU.vcxproj
+++ b/EngineSIU/EngineSIU/EngineSIU.vcxproj
@@ -504,6 +504,7 @@ xcopy /y /d "$(SolutionDir)$(ProjectName)\Engine\Source\ThirdParty\FBX\lib\x64\$
     <ClInclude Include="Engine\Source\Contents\AnimInstance\MyAnimInstance.h" />
     <ClInclude Include="Engine\Source\Contents\Components\FishBodyComponent.h" />
     <ClInclude Include="Engine\Source\Contents\Components\FishTailComponent.h" />
+    <ClInclude Include="Engine\Source\Runtime\CoreUObject\UObject\PropertyEvent.h"/>
     <ClInclude Include="Engine\Source\Contents\Objects\DamageCameraShake.h" />
     <ClInclude Include="Engine\Source\Developer\AnimDataController\AnimDataController.h" />
     <ClInclude Include="Engine\Source\Developer\LuaTypes\LuaUserTypes.h" />

--- a/EngineSIU/EngineSIU/imgui.ini
+++ b/EngineSIU/EngineSIU/imgui.ini
@@ -3,20 +3,20 @@ Pos=60,60
 Size=400,400
 
 [Window][Control Panel]
-Pos=0,0
-Size=1536,72
+Pos=1,1
+Size=1536,50
 
 [Window][Outliner]
-Pos=1540,5
-Size=379,341
+Pos=1541,5
+Size=378,341
 
 [Window][Detail]
-Pos=1540,351
-Size=379,753
+Pos=1541,356
+Size=378,739
 
 [Window][Console]
-Pos=0,1107
-Size=960,32
+Pos=0,-30
+Size=46,32
 Collapsed=1
 
 [Window][Engine Profiler]

--- a/EngineSIU/EngineSIU/imgui.ini
+++ b/EngineSIU/EngineSIU/imgui.ini
@@ -3,20 +3,20 @@ Pos=60,60
 Size=400,400
 
 [Window][Control Panel]
-Pos=1,1
-Size=1536,50
+Pos=0,0
+Size=1536,72
 
 [Window][Outliner]
-Pos=1541,5
-Size=378,341
+Pos=1540,5
+Size=379,341
 
 [Window][Detail]
-Pos=1541,356
-Size=378,739
+Pos=1540,351
+Size=379,753
 
 [Window][Console]
-Pos=0,-30
-Size=46,32
+Pos=0,1107
+Size=960,32
 Collapsed=1
 
 [Window][Engine Profiler]


### PR DESCRIPTION
## 주요 변경사항

- 주석 처리를 통해 사용되지 않는 `MemberProperty` 코드 정리
- `DisplayRawDataInImGui` 함수에 `OwnerObject` 파라미터 추가 및 데이터 변경 시 이벤트 처리 로직 구현
- `PostEditChangeProperty` 함수 추가 및 관련 헤더 선언
- `PropertyEvent.h` 파일 생성 및 프로젝트 파일(vcxproj)에 참조 수정