### PR TITLE
Fix: EditInline 지원 추가 및 재귀적 프로퍼티 표시 개선

### DIFF
--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Math/Vector.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Math/Vector.h
@@ -346,9 +346,9 @@ inline FVector FVector::operator*(float Scalar) const
 
 inline FVector& FVector::operator*=(const FVector& Other)
 {
-    X = Other.X;
-    Y = Other.Y;
-    Z = Other.Z;
+    X *= Other.X;
+    Y *= Other.Y;
+    Z *= Other.Z;
     return *this;
 }
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
@@ -59,6 +59,10 @@ public:
      */
     virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const;
 
+protected:
+    virtual void DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const;
+
+public:
     /** 런타임에 타입 정보를 검사하고 업데이트 합니다. */
     virtual void Resolve();
 
@@ -198,7 +202,8 @@ struct FInt8Property : public FNumericProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
+protected:
+    virtual void DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FInt16Property : public FNumericProperty
@@ -214,7 +219,8 @@ struct FInt16Property : public FNumericProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
+protected:
+    virtual void DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FInt32Property : public FNumericProperty
@@ -230,7 +236,8 @@ struct FInt32Property : public FNumericProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
+protected:
+    virtual void DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FInt64Property : public FNumericProperty
@@ -246,7 +253,8 @@ struct FInt64Property : public FNumericProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
+protected:
+    virtual void DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FUInt8Property : public FNumericProperty
@@ -262,7 +270,8 @@ struct FUInt8Property : public FNumericProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
+protected:
+    virtual void DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FUInt16Property : public FNumericProperty
@@ -278,7 +287,8 @@ struct FUInt16Property : public FNumericProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
+protected:
+    virtual void DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FUInt32Property : public FNumericProperty
@@ -294,7 +304,8 @@ struct FUInt32Property : public FNumericProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
+protected:
+    virtual void DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FUInt64Property : public FNumericProperty
@@ -310,7 +321,8 @@ struct FUInt64Property : public FNumericProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
+protected:
+    virtual void DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FFloatProperty : public FNumericProperty
@@ -326,7 +338,8 @@ struct FFloatProperty : public FNumericProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
+protected:
+    virtual void DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FDoubleProperty : public FNumericProperty
@@ -342,7 +355,8 @@ struct FDoubleProperty : public FNumericProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
+protected:
+    virtual void DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FBoolProperty : public FProperty
@@ -359,7 +373,9 @@ struct FBoolProperty : public FProperty
     }
 
     virtual void DisplayInImGui(UObject* Object) const override;
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
+
+protected:
+    virtual void DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FStrProperty : public FProperty
@@ -376,7 +392,9 @@ struct FStrProperty : public FProperty
     }
 
     virtual void DisplayInImGui(UObject* Object) const override;
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
+
+protected:
+    virtual void DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FNameProperty : public FProperty
@@ -391,7 +409,8 @@ struct FNameProperty : public FProperty
         : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Name, InSize, InOffset, InFlags)
     {}
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
+protected:
+    virtual void DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FVector2DProperty : public FProperty
@@ -408,7 +427,9 @@ struct FVector2DProperty : public FProperty
     }
 
     virtual void DisplayInImGui(UObject* Object) const override;
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
+
+protected:
+    virtual void DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FVectorProperty : public FProperty
@@ -425,7 +446,9 @@ struct FVectorProperty : public FProperty
     }
 
     virtual void DisplayInImGui(UObject* Object) const override;
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
+
+protected:
+    virtual void DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FVector4Property : public FProperty
@@ -442,7 +465,9 @@ struct FVector4Property : public FProperty
     }
 
     virtual void DisplayInImGui(UObject* Object) const override;
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
+
+protected:
+    virtual void DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FRotatorProperty : public FProperty
@@ -459,7 +484,9 @@ struct FRotatorProperty : public FProperty
     }
 
     virtual void DisplayInImGui(UObject* Object) const override;
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
+
+protected:
+    virtual void DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FQuatProperty : public FProperty
@@ -476,7 +503,9 @@ struct FQuatProperty : public FProperty
     }
 
     virtual void DisplayInImGui(UObject* Object) const override;
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
+
+protected:
+    virtual void DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FTransformProperty : public FProperty
@@ -492,7 +521,8 @@ struct FTransformProperty : public FProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
+protected:
+    virtual void DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FMatrixProperty : public FProperty
@@ -508,7 +538,8 @@ struct FMatrixProperty : public FProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
+protected:
+    virtual void DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FColorProperty : public FProperty
@@ -525,7 +556,9 @@ struct FColorProperty : public FProperty
     }
 
     virtual void DisplayInImGui(UObject* Object) const override;
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
+
+protected:
+    virtual void DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FLinearColorProperty : public FProperty
@@ -542,7 +575,9 @@ struct FLinearColorProperty : public FProperty
     }
 
     virtual void DisplayInImGui(UObject* Object) const override;
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
+
+protected:
+    virtual void DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 template <typename InArrayType>
@@ -563,9 +598,10 @@ struct TArrayProperty : public FProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override
+protected:
+    virtual void DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override
     {
-        FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
+        FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
         enum class EArrayElementOption : uint8
         {
@@ -694,9 +730,10 @@ struct TMapProperty : public FProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override
+protected:
+    virtual void DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override
     {
-        FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
+        FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
         enum class EMapElementOption : uint8
         {
@@ -848,9 +885,10 @@ struct TSetProperty : public FProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override
+protected:
+    virtual void DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override
     {
-        FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
+        FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
         enum class ESetElementOption : uint8
         {
@@ -984,9 +1022,10 @@ struct TEnumProperty : public FProperty
         ImGui::EndDisabled();
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override
+protected:
+    virtual void DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override
     {
-        FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
+        FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
         EnumType* Data = static_cast<EnumType*>(DataPtr);
         constexpr auto EnumEntries = magic_enum::enum_entries<EnumType>();
@@ -1035,10 +1074,12 @@ struct FSubclassOfProperty : public FProperty
     }
 
     virtual void DisplayInImGui(UObject* Object) const override;
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
+
+protected:
+    virtual void DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
-struct FObjectProperty : public FProperty
+struct FObjectProperty : public FProperty, public FDisplayMembersRecursiveTrait
 {
     FObjectProperty(
         UStruct* InOwnerStruct,
@@ -1051,10 +1092,11 @@ struct FObjectProperty : public FProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
+protected:
+    virtual void DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
-struct FStructProperty : public FProperty
+struct FStructProperty : public FProperty, public FDisplayMembersRecursiveTrait
 {
     FStructProperty(
         UStruct* InOwnerStruct,
@@ -1067,7 +1109,8 @@ struct FStructProperty : public FProperty
     {
     }
 
-    virtual void DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
+protected:
+    virtual void DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const override;
 };
 
 struct FUnresolvedPtrProperty : public FProperty

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
@@ -154,6 +154,19 @@ public:
     > TypeSpecificData;
 };
 
+/** Property를 Display할 때 부모순으로 출력할 수 있도록 도와주는 Trait Class */
+class FDisplayMembersRecursiveTrait
+{
+protected:
+    /**
+     * 구조체와 연결된 멤버를 재귀적으로 디스플레이합니다.
+     *
+     * @param CurrentStructToDisplay 현재 디스플레이할 UStruct.
+     * @param StructInstanceDataPtr 구조체 인스턴스 데이터에 대한 포인터.
+     * @param TopLevelOwnerObject 최상위 소유자 객체.
+     */
+    void DisplayMembersRecursive(const UStruct* CurrentStructToDisplay, void* StructInstanceDataPtr, UObject* TopLevelOwnerObject) const;
+};
 
 struct FNumericProperty : public FProperty
 {

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
@@ -66,17 +66,18 @@ struct FPropertyUIHelper
 
 void FProperty::DisplayInImGui(UObject* Object) const
 {
-    if (!HasAnyFlags(Flags, EPropertyFlags::EditAnywhere | EPropertyFlags::VisibleAnywhere))
-    {
-        return;
-    }
-
     void* Data = GetPropertyData(Object);
     DisplayRawDataInImGui(Name, Data, Object);
 }
 
 void FProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
+    if (!HasAnyFlags(Flags, EPropertyFlags::EditAnywhere | EPropertyFlags::VisibleAnywhere))
+    {
+        return;
+    }
+
+    DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 }
 
 void FProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
@@ -101,11 +101,8 @@ void FDisplayMembersRecursiveTrait::DisplayMembersRecursive(
 
     for (const FProperty* MemberProp : CurrentStructToDisplay->GetProperties())
     {
-        if (MemberProp)
-        {
-            void* MemberDataPtr = static_cast<std::byte*>(StructInstanceDataPtr) + MemberProp->Offset;
-            MemberProp->DisplayRawDataInImGui(MemberProp->Name, MemberDataPtr, TopLevelOwnerObject);
-        }
+        void* MemberDataPtr = static_cast<std::byte*>(StructInstanceDataPtr) + MemberProp->Offset;
+        MemberProp->DisplayRawDataInImGui(MemberProp->Name, MemberDataPtr, TopLevelOwnerObject);
     }
 }
 
@@ -679,14 +676,12 @@ void FObjectProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel,
 
                 if (HasAnyFlags(Flags, EPropertyFlags::EditInline))
                 {
-                    const UClass* ActualClass = ObjectClass;
-                    DisplayMembersRecursive(ActualClass, DataPtr, OwnerObject);
+                    DisplayMembersRecursive(ObjectClass, *Object, OwnerObject);
                 }
             }
             else if (HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere))
             {
-                const UClass* ActualClass = ObjectClass;
-                DisplayMembersRecursive(ActualClass, DataPtr, OwnerObject);
+                DisplayMembersRecursive(ObjectClass, *Object, OwnerObject);
             }
         }
         ImGui::TreePop();

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
@@ -676,12 +676,12 @@ void FObjectProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel,
 
                 if (HasAnyFlags(Flags, EPropertyFlags::EditInline))
                 {
-                    DisplayMembersRecursive(ObjectClass, *Object, OwnerObject);
+                    DisplayMembersRecursive(ObjectClass, *Object, *Object);
                 }
             }
             else if (HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere))
             {
-                DisplayMembersRecursive(ObjectClass, *Object, OwnerObject);
+                DisplayMembersRecursive(ObjectClass, *Object, *Object);
             }
         }
         ImGui::TreePop();

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
@@ -676,6 +676,12 @@ void FObjectProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel,
                     }
                     ImGui::EndCombo();
                 }
+
+                if (HasAnyFlags(Flags, EPropertyFlags::EditInline))
+                {
+                    const UClass* ActualClass = ObjectClass;
+                    DisplayMembersRecursive(ActualClass, DataPtr, OwnerObject);
+                }
             }
             else if (HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere))
             {

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
@@ -118,9 +118,9 @@ void FNumericProperty::DisplayInImGui(UObject* Object) const
     ImGui::EndDisabled();
 }
 
-void FInt8Property::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
+void FInt8Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FNumericProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
+    FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<int8>(PropertyLabel, DataPtr, 1);
     if (!ChangeResult.IsSet()) return;
@@ -129,9 +129,9 @@ void FInt8Property::DisplayRawDataInImGui(const char* PropertyLabel, void* DataP
     OwnerObject->PostEditChangeProperty(Event);
 }
 
-void FInt16Property::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
+void FInt16Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FNumericProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
+    FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<int16>(PropertyLabel, DataPtr, 1);
     if (!ChangeResult.IsSet()) return;
@@ -140,9 +140,9 @@ void FInt16Property::DisplayRawDataInImGui(const char* PropertyLabel, void* Data
     OwnerObject->PostEditChangeProperty(Event);
 }
 
-void FInt32Property::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
+void FInt32Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FNumericProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
+    FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<int32>(PropertyLabel, DataPtr, 1);
     if (!ChangeResult.IsSet()) return;
@@ -151,9 +151,9 @@ void FInt32Property::DisplayRawDataInImGui(const char* PropertyLabel, void* Data
     OwnerObject->PostEditChangeProperty(Event);
 }
 
-void FInt64Property::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
+void FInt64Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FNumericProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
+    FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<int64>(PropertyLabel, DataPtr, 1);
     if (!ChangeResult.IsSet()) return;
@@ -162,9 +162,9 @@ void FInt64Property::DisplayRawDataInImGui(const char* PropertyLabel, void* Data
     OwnerObject->PostEditChangeProperty(Event);
 }
 
-void FUInt8Property::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
+void FUInt8Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FNumericProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
+    FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<uint8>(PropertyLabel, DataPtr, 1);
     if (!ChangeResult.IsSet()) return;
@@ -173,9 +173,9 @@ void FUInt8Property::DisplayRawDataInImGui(const char* PropertyLabel, void* Data
     OwnerObject->PostEditChangeProperty(Event);
 }
 
-void FUInt16Property::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
+void FUInt16Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FNumericProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
+    FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<uint16>(PropertyLabel, DataPtr, 1);
     if (!ChangeResult.IsSet()) return;
@@ -184,9 +184,9 @@ void FUInt16Property::DisplayRawDataInImGui(const char* PropertyLabel, void* Dat
     OwnerObject->PostEditChangeProperty(Event);
 }
 
-void FUInt32Property::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
+void FUInt32Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FNumericProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
+    FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<uint32>(PropertyLabel, DataPtr, 1);
     if (!ChangeResult.IsSet()) return;
@@ -195,9 +195,9 @@ void FUInt32Property::DisplayRawDataInImGui(const char* PropertyLabel, void* Dat
     OwnerObject->PostEditChangeProperty(Event);
 }
 
-void FUInt64Property::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
+void FUInt64Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FNumericProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
+    FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<uint64>(PropertyLabel, DataPtr, 1);
     if (!ChangeResult.IsSet()) return;
@@ -206,9 +206,9 @@ void FUInt64Property::DisplayRawDataInImGui(const char* PropertyLabel, void* Dat
     OwnerObject->PostEditChangeProperty(Event);
 }
 
-void FFloatProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
+void FFloatProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FNumericProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
+    FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 1);
     if (!ChangeResult.IsSet()) return;
@@ -217,9 +217,9 @@ void FFloatProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* Data
     OwnerObject->PostEditChangeProperty(Event);
 }
 
-void FDoubleProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
+void FDoubleProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FNumericProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
+    FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<double>(PropertyLabel, DataPtr, 1);
     if (!ChangeResult.IsSet()) return;
@@ -237,9 +237,9 @@ void FBoolProperty::DisplayInImGui(UObject* Object) const
     ImGui::EndDisabled();
 }
 
-void FBoolProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
+void FBoolProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
+    FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     if (ImGui::Checkbox(PropertyLabel, static_cast<bool*>(DataPtr)))
     {
@@ -260,9 +260,9 @@ void FStrProperty::DisplayInImGui(UObject* Object) const
     ImGui::EndDisabled();
 }
 
-void FStrProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
+void FStrProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
+    FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     FString* Data = static_cast<FString*>(DataPtr);
 
@@ -300,9 +300,9 @@ void FStrProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPt
     }
 }
 
-void FNameProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
+void FNameProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
+    FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const FName* Data = static_cast<FName*>(DataPtr);
     std::string NameStr = Data->ToString().ToAnsiString();
@@ -326,9 +326,9 @@ void FVector2DProperty::DisplayInImGui(UObject* Object) const
     ImGui::EndDisabled();
 }
 
-void FVector2DProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
+void FVector2DProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
+    FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 2);
     if (!ChangeResult.IsSet()) return;
@@ -346,9 +346,9 @@ void FVectorProperty::DisplayInImGui(UObject* Object) const
     ImGui::EndDisabled();
 }
 
-void FVectorProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
+void FVectorProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
+    FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 3);
     if (!ChangeResult.IsSet()) return;
@@ -366,9 +366,9 @@ void FVector4Property::DisplayInImGui(UObject* Object) const
     ImGui::EndDisabled();
 }
 
-void FVector4Property::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
+void FVector4Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
+    FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 4);
     if (!ChangeResult.IsSet()) return;
@@ -386,9 +386,9 @@ void FRotatorProperty::DisplayInImGui(UObject* Object) const
     ImGui::EndDisabled();
 }
 
-void FRotatorProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
+void FRotatorProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
+    FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 3);
     if (!ChangeResult.IsSet()) return;
@@ -406,9 +406,9 @@ void FQuatProperty::DisplayInImGui(UObject* Object) const
     ImGui::EndDisabled();
 }
 
-void FQuatProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
+void FQuatProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
+    FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 4);
     if (!ChangeResult.IsSet()) return;
@@ -417,9 +417,9 @@ void FQuatProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataP
     OwnerObject->PostEditChangeProperty(Event);
 }
 
-void FTransformProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
+void FTransformProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
+    FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     if (ImGui::TreeNode(PropertyLabel))
     {
@@ -449,9 +449,9 @@ void FTransformProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* 
     }
 }
 
-void FMatrixProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
+void FMatrixProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
+    FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     // TODO: 짐벌락 현상 있음
     if (ImGui::TreeNode(PropertyLabel))
@@ -517,9 +517,9 @@ void FColorProperty::DisplayInImGui(UObject* Object) const
     ImGui::EndDisabled();
 }
 
-void FColorProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
+void FColorProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
+    FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     FColor* Data = static_cast<FColor*>(DataPtr);
     FLinearColor LinearColorForUI = FLinearColor(*Data);
@@ -553,9 +553,9 @@ void FLinearColorProperty::DisplayInImGui(UObject* Object) const
     ImGui::EndDisabled();
 }
 
-void FLinearColorProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
+void FLinearColorProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
+    FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     FLinearColor* Data = static_cast<FLinearColor*>(DataPtr);
 
@@ -586,9 +586,9 @@ void FSubclassOfProperty::DisplayInImGui(UObject* Object) const
     ImGui::EndDisabled();
 }
 
-void FSubclassOfProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
+void FSubclassOfProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
+    FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     TSubclassOf<UObject>* Data = static_cast<TSubclassOf<UObject>*>(DataPtr);
     UClass* CurrentClass = GetSpecificClass();
@@ -639,9 +639,9 @@ void FSubclassOfProperty::DisplayRawDataInImGui(const char* PropertyLabel, void*
     }
 }
 
-void FObjectProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
+void FObjectProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
+    FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     if (ImGui::TreeNodeEx(PropertyLabel, ImGuiTreeNodeFlags_Framed | ImGuiTreeNodeFlags_DefaultOpen))
     {
@@ -679,38 +679,24 @@ void FObjectProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* Dat
             }
             else if (HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere))
             {
-                const UClass* ChildClass = ObjectClass;
-                for (; ChildClass; ChildClass = ChildClass->GetSuperClass())
-                {
-                    for (const FProperty* Prop : ChildClass->GetProperties())
-                    {
-                        Prop->DisplayInImGui(*Object);
-                    }
-                }
+                const UClass* ActualClass = ObjectClass;
+                DisplayMembersRecursive(ActualClass, DataPtr, OwnerObject);
             }
         }
         ImGui::TreePop();
     }
 }
 
-void FStructProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
+void FStructProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
 {
-    FProperty::DisplayRawDataInImGui(PropertyLabel, DataPtr, OwnerObject);
+    FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     if (UScriptStruct* const* StructType = std::get_if<UScriptStruct*>(&TypeSpecificData))
     {
         if (ImGui::TreeNodeEx(PropertyLabel, ImGuiTreeNodeFlags_Framed | ImGuiTreeNodeFlags_DefaultOpen))
         {
-            // TODO: 나중에 Display 순서를 부모부터 띄우게 수정하기
-            UStruct* CurrentStruct = *StructType;
-            for (; CurrentStruct; CurrentStruct = CurrentStruct->GetSuperStruct())
-            {
-                for (const FProperty* Property : CurrentStruct->GetProperties())
-                {
-                    void* Data = static_cast<std::byte*>(DataPtr) + Property->Offset;
-                    Property->DisplayRawDataInImGui(Property->Name, Data, OwnerObject);
-                }
-            }
+            const UStruct* ActualStruct = *StructType;
+            DisplayMembersRecursive(ActualStruct, DataPtr, OwnerObject);
             ImGui::TreePop();
         }
     }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
@@ -79,6 +79,35 @@ void FProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, 
 {
 }
 
+void FProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
+{
+}
+
+void FDisplayMembersRecursiveTrait::DisplayMembersRecursive(
+    const UStruct* CurrentStructToDisplay, void* StructInstanceDataPtr, UObject* TopLevelOwnerObject
+) const
+{
+    if (!CurrentStructToDisplay)
+    {
+        return;
+    }
+
+    // 부모 구조체의 멤버 먼저 그리기
+    if (CurrentStructToDisplay->GetSuperStruct())
+    {
+        DisplayMembersRecursive(CurrentStructToDisplay->GetSuperStruct(), StructInstanceDataPtr, TopLevelOwnerObject);
+    }
+
+    for (const FProperty* MemberProp : CurrentStructToDisplay->GetProperties())
+    {
+        if (MemberProp)
+        {
+            void* MemberDataPtr = static_cast<std::byte*>(StructInstanceDataPtr) + MemberProp->Offset;
+            MemberProp->DisplayRawDataInImGui(MemberProp->Name, MemberDataPtr, TopLevelOwnerObject);
+        }
+    }
+}
+
 void FNumericProperty::DisplayInImGui(UObject* Object) const
 {
     ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyTypes.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyTypes.h
@@ -143,11 +143,15 @@ consteval EPropertyType GetPropertyType()
 
 enum EPropertyFlags : uint32  // NOLINT(performance-enum-size)
 {
-    PropertyNone    = 0,         // 플래그 없음
-    VisibleAnywhere = 1 << 0,    // ImGui에서 읽기 전용으로 표시
-    EditAnywhere    = 1 << 1,    // ImGui에서 읽기/쓰기 가능
-    LuaReadOnly     = 1 << 2,    // Lua에 읽기 전용으로 바인딩
-    LuaReadWrite    = 1 << 3,    // Lua에 읽기/쓰기로 바인딩
+    PropertyNone       = 0,       // 플래그 없음
+    VisibleAnywhere    = 1 << 0,  // ImGui에서 읽기 전용으로 표시
+    EditAnywhere       = 1 << 1,  // ImGui에서 읽기/쓰기 가능
+    EditInline         = 1 << 2,  // ImGui에서 Edit과 동시에 Inline으로 Object의 Property까지 표시
+    LuaReadOnly        = 1 << 3,  // Lua에 읽기 전용으로 바인딩
+    LuaReadWrite       = 1 << 4,  // Lua에 읽기/쓰기로 바인딩
+    BitField           = 1 << 5,  // BitField인 경우
+    Transient          = 1 << 6,  // 휘발성 변수인 경우 (이 값은 저장이 안됨)
+    DuplicateTransient = 1 << 7,  // Duplicate할 때 기본값으로 복제
     // ... 필요한 다른 플래그들 (예: SaveGame, Replicated 등)
 };
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/UObjectArray.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/UObjectArray.cpp
@@ -13,6 +13,8 @@ void FUObjectArray::AddObject(UObject* Object)
 
 void FUObjectArray::MarkRemoveObject(UObject* Object)
 {
+    if (!IsValid(Object)) return;
+
     ObjObjects.Remove(Object);
     RemoveFromClassMap(Object);  // UObjectHashTable에서 Object를 제외
     PendingDestroyObjects.AddUnique(Object);


### PR DESCRIPTION
## 주요 변경사항
> 아래 내용은 AI가 요약하였습니다.
- **FVector 곱셈 로직 수정 (덮어쓰기에서 곱셈으로 변경)**
- DisplayMembersRecursive 함수 호출 시 인자 오류 해결
- ObjectPropertyDisplay의 잘못된 값 표시 문제 수정
- 유효하지 않은 UObject 처리 로직 추가
- `EditInline` 속성 지원 추가:
    - DisplayMembersRecursive가 `EditInline`을 지원하도록 업데이트
    - `EditInline` 플래그 도입 및 프로퍼티 생성 로직에 플래그 검사 추가
- 구조체 내부 프로퍼티를 재귀적으로 표시할 때 발생하는 플래그 문제 수정
- 구조체 멤버를 재귀적으로 표시하는 기능 추가
