### PR TITLE
 Fix: TArray<T>같은 내부 속성에 대한 런타임 검사 추가

### DIFF
--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
@@ -1271,6 +1271,10 @@ FProperty* MakeProperty(
         constexpr std::string_view TypeName = GetTypeNameString<T>();
         FProperty* Property = new FUnresolvedPtrProperty{ InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags };
         Property->TypeSpecificData = FName(TypeName.data(), TypeName.size());
+
+        // 런타임 검사목록에 추가
+        UStruct::AddUnresolvedProperty(Property);
+
         return Property;
     }
     else if constexpr (TypeEnum == EPropertyType::Unknown)

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Struct.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Struct.cpp
@@ -10,6 +10,11 @@ TArray<FProperty*>& UStruct::GetUnresolvedProperties()
     return GUnresolvedProperties;
 }
 
+void UStruct::AddUnresolvedProperty(FProperty* Prop)
+{
+    GetUnresolvedProperties().Add(Prop);
+}
+
 void UStruct::ResolvePendingProperties()
 {
     for (FProperty* Prop : GetUnresolvedProperties())
@@ -68,11 +73,6 @@ void UStruct::AddProperty(FProperty* Prop)
     if (!Prop)
     {
         return;
-    }
-
-    if (Prop->Type == EPropertyType::UnresolvedPointer)
-    {
-        GetUnresolvedProperties().Add(Prop);
     }
 
     PropertiesSize += Prop->Size;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Struct.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Struct.cpp
@@ -29,6 +29,7 @@ UStruct::UStruct(
     UStruct* InSuperStruct
 )
     : StructSize(InStructSize)
+    , PropertiesSize(0)
     , MinAlignment(InAlignment)
     , SuperStruct(InSuperStruct)
 {

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Struct.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Struct.h
@@ -67,6 +67,9 @@ public:
      */
     virtual void SerializeBin(FArchive& Ar, void* Data);
 
+    /** 컴파일 타임에 알 수 없는 프로퍼티 타입을 검사 목록에 추가합니다. */
+    static void AddUnresolvedProperty(FProperty* Prop);
+
     /** 컴파일 타임에 알 수 없는 프로퍼티 타입을 런타임에 검사합니다.*/
     static void ResolvePendingProperties();
 


### PR DESCRIPTION
## 주요 변경사항

- 런타임 검사 시 알 수 없는 내부 속성도 포함할 수 있는 기능이 추가되었습니다.
- `Struct` 생성자에서 `PropertiesSize`가 초기화되지 않던 문제를 수정했습니다.
