### PR TITLE
Feature: Property 및 UI 컨트롤에 Metadata 지원

### DIFF
--- a/EngineSIU/EngineSIU/Engine/Source/Editor/UnrealEd/ImGuiWidget.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Editor/UnrealEd/ImGuiWidget.cpp
@@ -3,9 +3,9 @@
 #include "Math/Rotator.h"
 #include "Math/Vector.h"
 
-bool FImGuiWidget::DrawVec3Control(const std::string& Label, FVector& Values, float ResetValue, float ColumnWidth)
+bool FImGuiWidget::DrawVec3Control(const std::string& Label, FVector& Values, float ResetValue, float ColumnWidth, float Speed)
 {
-    return DisplayNControl<3>(Label, ResetValue, ColumnWidth, "%.2f",
+    return DisplayNControl<3>(Label, ResetValue, ColumnWidth, Speed, "%.2f",
     {{
         {
             .Label = "X",
@@ -31,9 +31,9 @@ bool FImGuiWidget::DrawVec3Control(const std::string& Label, FVector& Values, fl
     }});
 }
 
-bool FImGuiWidget::DrawRot3Control(const std::string& Label, FRotator& Values, float ResetValue, float ColumnWidth)
+bool FImGuiWidget::DrawRot3Control(const std::string& Label, FRotator& Values, float ResetValue, float ColumnWidth, float Speed)
 {
-    return DisplayNControl<3>(Label, ResetValue, ColumnWidth, "%.2f°",
+    return DisplayNControl<3>(Label, ResetValue, ColumnWidth, Speed, "%.2f°",
     {{
         {
             .Label = "Roll",

--- a/EngineSIU/EngineSIU/Engine/Source/Editor/UnrealEd/ImGuiWidget.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Editor/UnrealEd/ImGuiWidget.h
@@ -19,8 +19,8 @@ struct FControlInfo
 
 struct FImGuiWidget
 {
-    static bool DrawVec3Control(const std::string& Label, FVector& Values, float ResetValue = 0.0f, float ColumnWidth = 100.0f);
-    static bool DrawRot3Control(const std::string& Label, FRotator& Values, float ResetValue = 0.0f, float ColumnWidth = 100.0f);
+    static bool DrawVec3Control(const std::string& Label, FVector& Values, float ResetValue = 0.0f, float ColumnWidth = 100.0f, float Speed = 0.1f);
+    static bool DrawRot3Control(const std::string& Label, FRotator& Values, float ResetValue = 0.0f, float ColumnWidth = 100.0f, float Speed = 0.1f);
     static void DrawDragInt(const std::string& label, int& value, int min = 0, int max = 0, float width = 100.0f);
     static void DrawDragFloat(const std::string& label, float& value, float min = 0.0f, float max = 0.0f, float width = 100.0f);
 
@@ -29,6 +29,7 @@ struct FImGuiWidget
         const std::string& Label,
         float ResetValue,
         float ColumnWidth,
+        float Speed,
         const char* Format,
         const std::array<FControlInfo, N>& ComponentsInfo
     )
@@ -95,7 +96,7 @@ struct FImGuiWidget
                 ("##" + Info.Label + "Drag").c_str(),
                 ImGuiDataType_Float,
                 Info.ValuePtr,
-                0.1f,
+                Speed,
                 &Min, &Max, Format
             ))
             {

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ObjectMacros.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ObjectMacros.h
@@ -157,7 +157,7 @@ public: \
  * 
  * UPROPERTY(EPropertyFlags::EditAnywhere, int, Value, = 10) // Flag를 지정하면 기본값은 필수
  * 
- * UPROPERTY(EPropertyFlags::EditAnywhere, { .Category="NewCategory" }, int, Value, = 10) // Metadata를 지정하면 Flag와 기본값은 필수
+ * UPROPERTY(EPropertyFlags::EditAnywhere, ({ .Category="NewCategory", .DisplayName="MyValue" }), int, Value, = 10) // Metadata를 지정하면 Flag와 기본값은 필수
  */
 #define UPROPERTY(...) \
     EXPAND_MACRO(GET_OVERLOADED_PROPERTY_MACRO(__VA_ARGS__, UPROPERTY_WITH_METADATA, UPROPERTY_WITH_FLAGS, UPROPERTY_DEFAULT, UPROPERTY_DEFAULT)(__VA_ARGS__))

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ObjectMacros.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ObjectMacros.h
@@ -118,7 +118,7 @@ public: \
 #define GET_FIRST_ARG(First, ...) First
 #define FIRST_ARG(...) GET_FIRST_ARG(__VA_ARGS__, )
 
-#define UPROPERTY_WITH_FLAGS(InFlags, InType, InVarName, ...) \
+#define UPROPERTY_WITH_METADATA(InFlags, InMetadata, InType, InVarName, ...) \
     InType InVarName FIRST_ARG(__VA_ARGS__); \
     inline static struct InVarName##_PropRegistrar_PRIVATE \
     { \
@@ -128,21 +128,26 @@ public: \
             constexpr EPropertyFlags Flags = InFlags; \
             UStruct* StructPtr = GetStructHelper<ThisClass>(); \
             StructPtr->AddProperty( \
-                PropertyFactory::Private::MakeProperty<InType, Flags>(StructPtr, #InVarName, Offset) \
+                PropertyFactory::Private::MakeProperty<InType, Flags>( \
+                    StructPtr, \
+                    #InVarName, \
+                    Offset, \
+                    FPropertyMetadata InMetadata \
+                ) \
             ); \
         } \
     } InVarName##_PropRegistrar_PRIVATE{};
 
+#define UPROPERTY_WITH_FLAGS(InFlags, InType, InVarName, ...) \
+    UPROPERTY_WITH_METADATA(InFlags, {}, InType, InVarName, __VA_ARGS__)
+
 #define UPROPERTY_DEFAULT(InType, InVarName, ...) \
     UPROPERTY_WITH_FLAGS(EPropertyFlags::PropertyNone, InType, InVarName, __VA_ARGS__)
 
-#define GET_OVERLOADED_PROPERTY_MACRO(_1, _2, _3, _4, MACRO, ...) MACRO
+#define GET_OVERLOADED_PROPERTY_MACRO(_1, _2, _3, _4, _5, MACRO, ...) MACRO
 
 /**
  * UClass에 Property를 등록합니다.
- * @param Type 선언할 타입
- * @param VarName 변수 이름
- * @param ... 기본값
  *
  * ----- Example Code -----
  * 
@@ -151,6 +156,8 @@ public: \
  * UPROPERTY(int, Value, = 10)
  * 
  * UPROPERTY(EPropertyFlags::EditAnywhere, int, Value, = 10) // Flag를 지정하면 기본값은 필수
+ * 
+ * UPROPERTY(EPropertyFlags::EditAnywhere, { .Category="NewCategory" }, int, Value, = 10) // Metadata를 지정하면 Flag와 기본값은 필수
  */
 #define UPROPERTY(...) \
-    EXPAND_MACRO(GET_OVERLOADED_PROPERTY_MACRO(__VA_ARGS__, UPROPERTY_WITH_FLAGS, UPROPERTY_DEFAULT, UPROPERTY_DEFAULT)(__VA_ARGS__))
+    EXPAND_MACRO(GET_OVERLOADED_PROPERTY_MACRO(__VA_ARGS__, UPROPERTY_WITH_METADATA, UPROPERTY_WITH_FLAGS, UPROPERTY_DEFAULT, UPROPERTY_DEFAULT)(__VA_ARGS__))

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.cpp
@@ -27,7 +27,7 @@ void FUnresolvedPtrProperty::Resolve()
             {
                 Type = EPropertyType::Object;
                 TypeSpecificData = FoundClass;
-                ResolvedProperty = new FObjectProperty{OwnerStruct, Name, Size, Offset, Flags};
+                ResolvedProperty = new FObjectProperty{OwnerStruct, Name, Size, Offset, Flags, std::move(Metadata)};
                 ResolvedProperty->TypeSpecificData = TypeSpecificData;
                 return;
             }
@@ -37,7 +37,7 @@ void FUnresolvedPtrProperty::Resolve()
             {
                 Type = EPropertyType::Struct;
                 TypeSpecificData = FoundStruct;
-                ResolvedProperty = new FStructProperty{OwnerStruct, Name, Size, Offset, Flags};
+                ResolvedProperty = new FStructProperty{OwnerStruct, Name, Size, Offset, Flags, std::move(Metadata)};
                 ResolvedProperty->TypeSpecificData = TypeSpecificData;
                 return;
             }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
@@ -3,6 +3,7 @@
 #include <optional>
 
 #include "PropertyEvent.h"
+#include "PropertyMetadata.h"
 #include "PropertyTypes.h"
 #include "Struct.h"
 #include "Container/Queue.h"
@@ -23,6 +24,7 @@ struct FProperty
      * @param InSize 프로퍼티의 크기
      * @param InOffset 프로퍼티가 클래스로부터 떨어진 거리
      * @param InFlags Reflection 관련 Flag
+     * @param InMetadata 추가 Property에 대한 Metadata
      */
     FProperty(
         UStruct* InOwnerStruct,
@@ -30,7 +32,8 @@ struct FProperty
         EPropertyType InType,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata = FPropertyMetadata{}
     )
         : OwnerStruct(InOwnerStruct)
         , Name(InPropertyName)
@@ -38,6 +41,7 @@ struct FProperty
         , Size(InSize)
         , Offset(InOffset)
         , Flags(InFlags)
+        , Metadata(std::move(InMetadata))
     {
     }
 
@@ -148,6 +152,7 @@ public:
     int64 Size;
     int64 Offset;
     EPropertyFlags Flags;
+    FPropertyMetadata Metadata;
 
 public:
     std::variant<

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
@@ -1,4 +1,5 @@
 ﻿#pragma once
+#include <utility>
 #include <variant>
 #include <optional>
 
@@ -33,7 +34,7 @@ struct FProperty
         int64 InSize,
         int64 InOffset,
         EPropertyFlags InFlags,
-        FPropertyMetadata InMetadata = FPropertyMetadata{}
+        FPropertyMetadata InMetadata
     )
         : OwnerStruct(InOwnerStruct)
         , Name(InPropertyName)
@@ -185,9 +186,10 @@ struct FNumericProperty : public FProperty
         EPropertyType InType,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FProperty(InOwnerStruct, InPropertyName, InType, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, InType, InSize, InOffset, InFlags, std::move(InMetadata))
     {
     }
 
@@ -201,9 +203,10 @@ struct FInt8Property : public FNumericProperty
         const char* InPropertyName,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::Int8, InSize, InOffset, InFlags)
+        : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::Int8, InSize, InOffset, InFlags, std::move(InMetadata))
     {
     }
 
@@ -218,9 +221,10 @@ struct FInt16Property : public FNumericProperty
         const char* InPropertyName,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::Int16, InSize, InOffset, InFlags)
+        : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::Int16, InSize, InOffset, InFlags, std::move(InMetadata))
     {
     }
 
@@ -235,9 +239,10 @@ struct FInt32Property : public FNumericProperty
         const char* InPropertyName,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::Int32, InSize, InOffset, InFlags)
+        : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::Int32, InSize, InOffset, InFlags, std::move(InMetadata))
     {
     }
 
@@ -252,9 +257,10 @@ struct FInt64Property : public FNumericProperty
         const char* InPropertyName,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::Int64, InSize, InOffset, InFlags)
+        : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::Int64, InSize, InOffset, InFlags, std::move(InMetadata))
     {
     }
 
@@ -269,9 +275,10 @@ struct FUInt8Property : public FNumericProperty
         const char* InPropertyName,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::UInt8, InSize, InOffset, InFlags)
+        : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::UInt8, InSize, InOffset, InFlags, std::move(InMetadata))
     {
     }
 
@@ -286,9 +293,10 @@ struct FUInt16Property : public FNumericProperty
         const char* InPropertyName,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::UInt16, InSize, InOffset, InFlags)
+        : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::UInt16, InSize, InOffset, InFlags, std::move(InMetadata))
     {
     }
 
@@ -303,9 +311,10 @@ struct FUInt32Property : public FNumericProperty
         const char* InPropertyName,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::UInt32, InSize, InOffset, InFlags)
+        : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::UInt32, InSize, InOffset, InFlags, std::move(InMetadata))
     {
     }
 
@@ -320,9 +329,10 @@ struct FUInt64Property : public FNumericProperty
         const char* InPropertyName,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::UInt64, InSize, InOffset, InFlags)
+        : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::UInt64, InSize, InOffset, InFlags, std::move(InMetadata))
     {
     }
 
@@ -337,9 +347,10 @@ struct FFloatProperty : public FNumericProperty
         const char* InPropertyName,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::Float, InSize, InOffset, InFlags)
+        : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::Float, InSize, InOffset, InFlags, std::move(InMetadata))
     {
     }
 
@@ -354,9 +365,10 @@ struct FDoubleProperty : public FNumericProperty
         const char* InPropertyName,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::Double, InSize, InOffset, InFlags)
+        : FNumericProperty(InOwnerStruct, InPropertyName, EPropertyType::Double, InSize, InOffset, InFlags, std::move(InMetadata))
     {
     }
 
@@ -371,9 +383,10 @@ struct FBoolProperty : public FProperty
         const char* InPropertyName,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Bool, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Bool, InSize, InOffset, InFlags, std::move(InMetadata))
     {
     }
 
@@ -390,9 +403,10 @@ struct FStrProperty : public FProperty
         const char* InPropertyName,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::String, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::String, InSize, InOffset, InFlags, std::move(InMetadata))
     {
     }
 
@@ -409,9 +423,10 @@ struct FNameProperty : public FProperty
         const char* InPropertyName,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Name, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Name, InSize, InOffset, InFlags, std::move(InMetadata))
     {}
 
 protected:
@@ -425,9 +440,10 @@ struct FVector2DProperty : public FProperty
         const char* InPropertyName,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Vector2D, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Vector2D, InSize, InOffset, InFlags, std::move(InMetadata))
     {
     }
 
@@ -444,9 +460,10 @@ struct FVectorProperty : public FProperty
         const char* InPropertyName,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Vector, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Vector, InSize, InOffset, InFlags, std::move(InMetadata))
     {
     }
 
@@ -463,9 +480,10 @@ struct FVector4Property : public FProperty
         const char* InPropertyName,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Vector4, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Vector4, InSize, InOffset, InFlags, std::move(InMetadata))
     {
     }
 
@@ -482,9 +500,10 @@ struct FRotatorProperty : public FProperty
         const char* InPropertyName,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Rotator, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Rotator, InSize, InOffset, InFlags, std::move(InMetadata))
     {
     }
 
@@ -501,9 +520,10 @@ struct FQuatProperty : public FProperty
         const char* InPropertyName,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Quat, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Quat, InSize, InOffset, InFlags, std::move(InMetadata))
     {
     }
 
@@ -520,9 +540,10 @@ struct FTransformProperty : public FProperty
         const char* InPropertyName,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Transform, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Transform, InSize, InOffset, InFlags, std::move(InMetadata))
     {
     }
 
@@ -537,9 +558,10 @@ struct FMatrixProperty : public FProperty
         const char* InPropertyName,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Matrix, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Matrix, InSize, InOffset, InFlags, std::move(InMetadata))
     {
     }
 
@@ -554,9 +576,10 @@ struct FColorProperty : public FProperty
         const char* InPropertyName,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Color, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Color, InSize, InOffset, InFlags, std::move(InMetadata))
     {
     }
 
@@ -573,9 +596,10 @@ struct FLinearColorProperty : public FProperty
         const char* InPropertyName,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::LinearColor, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::LinearColor, InSize, InOffset, InFlags, std::move(InMetadata))
     {
     }
 
@@ -597,9 +621,10 @@ struct TArrayProperty : public FProperty
         const char* InPropertyName,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Array, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Array, InSize, InOffset, InFlags, std::move(InMetadata))
     {
     }
 
@@ -729,9 +754,10 @@ struct TMapProperty : public FProperty
         const char* InPropertyName,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Map, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Map, InSize, InOffset, InFlags, std::move(InMetadata))
     {
     }
 
@@ -884,9 +910,10 @@ struct TSetProperty : public FProperty
         const char* InPropertyName,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Set, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Set, InSize, InOffset, InFlags, std::move(InMetadata))
     {
     }
 
@@ -1012,9 +1039,10 @@ struct TEnumProperty : public FProperty
         const char* InPropertyName,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Enum, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Enum, InSize, InOffset, InFlags, std::move(InMetadata))
     {
     }
 
@@ -1072,9 +1100,10 @@ struct FSubclassOfProperty : public FProperty
         const char* InPropertyName,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::SubclassOf, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::SubclassOf, InSize, InOffset, InFlags, std::move(InMetadata))
     {
     }
 
@@ -1091,9 +1120,10 @@ struct FObjectProperty : public FProperty, public FDisplayMembersRecursiveTrait
         const char* InPropertyName,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Object, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Object, InSize, InOffset, InFlags, std::move(InMetadata))
     {
     }
 
@@ -1108,9 +1138,10 @@ struct FStructProperty : public FProperty, public FDisplayMembersRecursiveTrait
         const char* InPropertyName,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Struct, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::Struct, InSize, InOffset, InFlags, std::move(InMetadata))
     {
     }
 
@@ -1127,9 +1158,10 @@ struct FUnresolvedPtrProperty : public FProperty
         const char* InPropertyName,
         int64 InSize,
         int64 InOffset,
-        EPropertyFlags InFlags
+        EPropertyFlags InFlags,
+        FPropertyMetadata InMetadata
     )
-        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::UnresolvedPointer, InSize, InOffset, InFlags)
+        : FProperty(InOwnerStruct, InPropertyName, EPropertyType::UnresolvedPointer, InSize, InOffset, InFlags, std::move(InMetadata))
     {
     }
 
@@ -1160,7 +1192,8 @@ template <typename T, EPropertyFlags InFlags>
 FProperty* MakeProperty(
     UStruct* InOwnerStruct,
     const char* InPropertyName,
-    int32 InOffset
+    int32 InOffset,
+    FPropertyMetadata InMetadata
 )
 {
     // 각 타입에 맞는 Property 생성
@@ -1186,75 +1219,75 @@ FProperty* MakeProperty(
         static_assert(TAlwaysFalse<T>, "EditInline cannot be set for non-UObject types.");
     }
 
-    if constexpr      (TypeEnum == EPropertyType::Int8)        { return new FInt8Property        { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Int16)       { return new FInt16Property       { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Int32)       { return new FInt32Property       { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Int64)       { return new FInt64Property       { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::UInt8)       { return new FUInt8Property       { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::UInt16)      { return new FUInt16Property      { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::UInt32)      { return new FUInt32Property      { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::UInt64)      { return new FUInt64Property      { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Float)       { return new FFloatProperty       { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Double)      { return new FDoubleProperty      { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Bool)        { return new FBoolProperty        { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
+    if constexpr      (TypeEnum == EPropertyType::Int8)        { return new FInt8Property        { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) }; }
+    else if constexpr (TypeEnum == EPropertyType::Int16)       { return new FInt16Property       { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) }; }
+    else if constexpr (TypeEnum == EPropertyType::Int32)       { return new FInt32Property       { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) }; }
+    else if constexpr (TypeEnum == EPropertyType::Int64)       { return new FInt64Property       { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) }; }
+    else if constexpr (TypeEnum == EPropertyType::UInt8)       { return new FUInt8Property       { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) }; }
+    else if constexpr (TypeEnum == EPropertyType::UInt16)      { return new FUInt16Property      { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) }; }
+    else if constexpr (TypeEnum == EPropertyType::UInt32)      { return new FUInt32Property      { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) }; }
+    else if constexpr (TypeEnum == EPropertyType::UInt64)      { return new FUInt64Property      { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) }; }
+    else if constexpr (TypeEnum == EPropertyType::Float)       { return new FFloatProperty       { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) }; }
+    else if constexpr (TypeEnum == EPropertyType::Double)      { return new FDoubleProperty      { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) }; }
+    else if constexpr (TypeEnum == EPropertyType::Bool)        { return new FBoolProperty        { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) }; }
 
-    else if constexpr (TypeEnum == EPropertyType::String)      { return new FStrProperty         { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Name)        { return new FNameProperty        { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Vector2D)    { return new FVector2DProperty    { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Vector)      { return new FVectorProperty      { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Vector4)     { return new FVector4Property     { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Rotator)     { return new FRotatorProperty     { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Quat)        { return new FQuatProperty        { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Transform)   { return new FTransformProperty   { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Matrix)      { return new FMatrixProperty      { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::Color)       { return new FColorProperty       { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
-    else if constexpr (TypeEnum == EPropertyType::LinearColor) { return new FLinearColorProperty { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags }; }
+    else if constexpr (TypeEnum == EPropertyType::String)      { return new FStrProperty         { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) }; }
+    else if constexpr (TypeEnum == EPropertyType::Name)        { return new FNameProperty        { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) }; }
+    else if constexpr (TypeEnum == EPropertyType::Vector2D)    { return new FVector2DProperty    { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) }; }
+    else if constexpr (TypeEnum == EPropertyType::Vector)      { return new FVectorProperty      { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) }; }
+    else if constexpr (TypeEnum == EPropertyType::Vector4)     { return new FVector4Property     { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) }; }
+    else if constexpr (TypeEnum == EPropertyType::Rotator)     { return new FRotatorProperty     { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) }; }
+    else if constexpr (TypeEnum == EPropertyType::Quat)        { return new FQuatProperty        { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) }; }
+    else if constexpr (TypeEnum == EPropertyType::Transform)   { return new FTransformProperty   { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) }; }
+    else if constexpr (TypeEnum == EPropertyType::Matrix)      { return new FMatrixProperty      { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) }; }
+    else if constexpr (TypeEnum == EPropertyType::Color)       { return new FColorProperty       { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) }; }
+    else if constexpr (TypeEnum == EPropertyType::LinearColor) { return new FLinearColorProperty { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) }; }
 
     else if constexpr (TypeEnum == EPropertyType::Array)
     {
-        TArrayProperty<T>* Property = new TArrayProperty<T> { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags };
+        TArrayProperty<T>* Property = new TArrayProperty<T> { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) };
         Property->ElementProperty = CreatePropertyForContainerType<typename T::ElementType, InFlags>();
         return Property;
     }
     else if constexpr (TypeEnum == EPropertyType::Map)
     {
-        TMapProperty<T>* Property = new TMapProperty<T> { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags };
+        TMapProperty<T>* Property = new TMapProperty<T> { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) };
         Property->KeyProperty = CreatePropertyForContainerType<typename T::KeyType, InFlags>();
         Property->ValueProperty = CreatePropertyForContainerType<typename T::ValueType, InFlags>();
         return Property;
     }
     else if constexpr (TypeEnum == EPropertyType::Set)
     {
-        TSetProperty<T>* Property = new TSetProperty<T> { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags };
+        TSetProperty<T>* Property = new TSetProperty<T> { InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) };
         Property->ElementProperty = CreatePropertyForContainerType<typename T::ElementType, InFlags>();
         return Property;
     }
 
     else if constexpr (TypeEnum == EPropertyType::Enum)
     {
-        return new TEnumProperty<T>{ InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags };
+        return new TEnumProperty<T>{ InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) };
     }
     else if constexpr (TypeEnum == EPropertyType::Struct)
     {
-        FProperty* Property = new FStructProperty{ InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags };
+        FProperty* Property = new FStructProperty{ InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) };
         Property->TypeSpecificData = T::StaticStruct();
         return Property;
     }
     else if constexpr (TypeEnum == EPropertyType::StructPointer)
     {
         using PointerType = std::remove_cvref_t<std::remove_pointer_t<T>>;
-        FUnresolvedPtrProperty* Property = new FUnresolvedPtrProperty{ InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags };
+        FUnresolvedPtrProperty* Property = new FUnresolvedPtrProperty{ InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, InMetadata };
 
         Property->Type = EPropertyType::Struct;
         Property->TypeSpecificData = PointerType::StaticStruct();
-        Property->ResolvedProperty = new FStructProperty{ InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags };
+        Property->ResolvedProperty = new FStructProperty{ InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) };
         return Property;
     }
     else if constexpr (TypeEnum == EPropertyType::SubclassOf)
     {
         if constexpr (std::derived_from<typename T::ElementType, UObject>)
         {
-            FProperty* Property = new FSubclassOfProperty{ InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags };
+            FProperty* Property = new FSubclassOfProperty{ InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) };
             Property->TypeSpecificData = T::ElementType::StaticClass();
             return Property;
         }
@@ -1267,14 +1300,14 @@ FProperty* MakeProperty(
     else if constexpr (TypeEnum == EPropertyType::Object)
     {
         using PointerType = std::remove_cvref_t<std::remove_pointer_t<T>>;
-        FProperty* Property = new FObjectProperty{ InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags };
+        FProperty* Property = new FObjectProperty{ InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) };
         Property->TypeSpecificData = PointerType::StaticClass();
         return Property;
     }
     else if constexpr (TypeEnum == EPropertyType::UnresolvedPointer)
     {
         constexpr std::string_view TypeName = GetTypeNameString<T>();
-        FProperty* Property = new FUnresolvedPtrProperty{ InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags };
+        FProperty* Property = new FUnresolvedPtrProperty{ InOwnerStruct, InPropertyName, sizeof(T), InOffset, InFlags, std::move(InMetadata) };
         Property->TypeSpecificData = FName(TypeName.data(), TypeName.size());
         return Property;
     }
@@ -1310,7 +1343,8 @@ FProperty* CreatePropertyForContainerType()
     return MakeProperty<T, InFlags>(
         nullptr,
         "InnerProperty", // 실제 컨테이너 항목은 이 이름을 사용하지 않음
-        0
+        0,
+        {}
     );
 }
 }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Property.h
@@ -642,6 +642,12 @@ protected:
 
         if (ImGui::TreeNode(PropertyLabel))
         {
+            // 툴팁 표시
+            if (Metadata.ToolTip.IsSet())
+            {
+                ImGui::SetItemTooltip("%s", **Metadata.ToolTip);
+            }
+
             ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));
             {
                 TOptional<FPropertyChangedEvent> Event;
@@ -775,6 +781,12 @@ protected:
 
         if (ImGui::TreeNode(PropertyLabel))
         {
+            // 툴팁 표시
+            if (Metadata.ToolTip.IsSet())
+            {
+                ImGui::SetItemTooltip("%s", **Metadata.ToolTip);
+            }
+
             ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));
             {
                 // TODO: 나중에 추가
@@ -931,6 +943,12 @@ protected:
     
         if (ImGui::TreeNode(PropertyLabel))
         {
+            // 툴팁 표시
+            if (Metadata.ToolTip.IsSet())
+            {
+                ImGui::SetItemTooltip("%s", **Metadata.ToolTip);
+            }
+
             ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));
             {
                 // TODO: 나중에 추가
@@ -1067,6 +1085,11 @@ protected:
         const std::string CurrentName = std::string(CurrentNameView);
 
         ImGui::Text("%s", PropertyLabel);
+        // 툴팁 표시
+        if (Metadata.ToolTip.IsSet())
+        {
+            ImGui::SetItemTooltip("%s", **Metadata.ToolTip);
+        }
         ImGui::SameLine();
         if (ImGui::BeginCombo(std::format("##{}", PropertyLabel).c_str(), CurrentName.c_str()))
         {

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
@@ -27,14 +27,15 @@ struct FPropertyUIHelper
         const char* PropertyLabel,
         void* InData,
         int Components,
-        float Speed = 1.0f,
-        const char* Format = nullptr,
-        const char* ToolTip = nullptr
+        const FPropertyMetadata& Metadata,
+        const char* Format = nullptr
     )
     {
         NumType* Data = static_cast<NumType*>(InData);
-        constexpr NumType Min = TNumericLimits<NumType>::Lowest();
-        constexpr NumType Max = TNumericLimits<NumType>::Max();
+
+        // Drag Clamping
+        const NumType ClampMin = Metadata.ClampMin.IsSet() ? static_cast<NumType>(*Metadata.ClampMin) : TNumericLimits<NumType>::Lowest();
+        const NumType ClampMax = Metadata.ClampMax.IsSet() ? static_cast<NumType>(*Metadata.ClampMax) : TNumericLimits<NumType>::Max();
 
         ImGuiDataType DataType;
         if constexpr (std::same_as<NumType, int8>)        { DataType = ImGuiDataType_S8;     }
@@ -50,13 +51,22 @@ struct FPropertyUIHelper
         else { static_assert(TAlwaysFalse<NumType>); }
 
         ImGui::Text("%s", PropertyLabel);
-        if (ToolTip)
+        if (Metadata.ToolTip.IsSet())
         {
-            ImGui::SetItemTooltip("%s", ToolTip);
+            ImGui::SetItemTooltip("%s", **Metadata.ToolTip);
         }
         ImGui::SameLine();
         const std::string FormatStr = std::format("##{}", PropertyLabel);
-        const bool bIsInteractive = ImGui::DragScalarN(FormatStr.c_str(), DataType, Data, Components, Speed, &Min, &Max, Format);
+        const bool bIsInteractive = ImGui::DragScalarN(
+            FormatStr.c_str(),
+            DataType,
+            Data, Components,
+            // Metadata.DragDeltaSpeed,
+            1,
+            &ClampMin, &ClampMax,
+            Format,
+            ImGuiSliderFlags_AlwaysClamp
+        );
 
         if (ImGui::IsItemDeactivatedAfterEdit())
         {
@@ -128,16 +138,8 @@ void FInt8Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel, v
 {
     FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    const float DeltaSensitivity = Metadata.LinearDeltaSensitivity;
-    const char* ToolTip = Metadata.ToolTip.IsSet() ? **Metadata.ToolTip : nullptr;
-
-    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<int8>(
-        PropertyLabel,
-        DataPtr, 1,
-        DeltaSensitivity,
-        nullptr,
-        ToolTip
-    );
+    const TOptional<EPropertyChangeType> ChangeResult =
+        FPropertyUIHelper::DisplayNumericDragN<int8>(PropertyLabel, DataPtr, 1, Metadata);
     if (!ChangeResult.IsSet())
     {
         return;
@@ -151,16 +153,8 @@ void FInt16Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel, 
 {
     FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    const float DeltaSensitivity = Metadata.LinearDeltaSensitivity;
-    const char* ToolTip = Metadata.ToolTip.IsSet() ? **Metadata.ToolTip : nullptr;
-
-    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<int16>(
-        PropertyLabel,
-        DataPtr, 1,
-        DeltaSensitivity,
-        nullptr,
-        ToolTip
-    );
+    const TOptional<EPropertyChangeType> ChangeResult =
+        FPropertyUIHelper::DisplayNumericDragN<int16>(PropertyLabel, DataPtr, 1, Metadata);
     if (!ChangeResult.IsSet())
     {
         return;
@@ -174,16 +168,8 @@ void FInt32Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel, 
 {
     FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    const float DeltaSensitivity = Metadata.LinearDeltaSensitivity;
-    const char* ToolTip = Metadata.ToolTip.IsSet() ? **Metadata.ToolTip : nullptr;
-
-    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<int32>(
-        PropertyLabel,
-        DataPtr, 1,
-        DeltaSensitivity,
-        nullptr,
-        ToolTip
-    );
+    const TOptional<EPropertyChangeType> ChangeResult =
+        FPropertyUIHelper::DisplayNumericDragN<int32>(PropertyLabel, DataPtr, 1, Metadata);
     if (!ChangeResult.IsSet())
     {
         return;
@@ -197,16 +183,8 @@ void FInt64Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel, 
 {
     FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    const float DeltaSensitivity = Metadata.LinearDeltaSensitivity;
-    const char* ToolTip = Metadata.ToolTip.IsSet() ? **Metadata.ToolTip : nullptr;
-
-    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<int64>(
-        PropertyLabel,
-        DataPtr, 1,
-        DeltaSensitivity,
-        nullptr,
-        ToolTip
-    );
+    const TOptional<EPropertyChangeType> ChangeResult =
+        FPropertyUIHelper::DisplayNumericDragN<int64>(PropertyLabel, DataPtr, 1, Metadata);
     if (!ChangeResult.IsSet())
     {
         return;
@@ -220,16 +198,8 @@ void FUInt8Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel, 
 {
     FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    const float DeltaSensitivity = Metadata.LinearDeltaSensitivity;
-    const char* ToolTip = Metadata.ToolTip.IsSet() ? **Metadata.ToolTip : nullptr;
-
-    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<uint8>(
-        PropertyLabel,
-        DataPtr, 1,
-        DeltaSensitivity,
-        nullptr,
-        ToolTip
-    );
+    const TOptional<EPropertyChangeType> ChangeResult =
+        FPropertyUIHelper::DisplayNumericDragN<uint8>(PropertyLabel, DataPtr, 1, Metadata);
     if (!ChangeResult.IsSet())
     {
         return;
@@ -243,16 +213,8 @@ void FUInt16Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel,
 {
     FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    const float DeltaSensitivity = Metadata.LinearDeltaSensitivity;
-    const char* ToolTip = Metadata.ToolTip.IsSet() ? **Metadata.ToolTip : nullptr;
-
-    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<uint16>(
-        PropertyLabel,
-        DataPtr, 1,
-        DeltaSensitivity,
-        nullptr,
-        ToolTip
-    );
+    const TOptional<EPropertyChangeType> ChangeResult =
+        FPropertyUIHelper::DisplayNumericDragN<uint16>(PropertyLabel, DataPtr, 1, Metadata);
     if (!ChangeResult.IsSet())
     {
         return;
@@ -266,16 +228,8 @@ void FUInt32Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel,
 {
     FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    const float DeltaSensitivity = Metadata.LinearDeltaSensitivity;
-    const char* ToolTip = Metadata.ToolTip.IsSet() ? **Metadata.ToolTip : nullptr;
-
-    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<uint32>(
-        PropertyLabel,
-        DataPtr, 1,
-        DeltaSensitivity,
-        nullptr,
-        ToolTip
-    );
+    const TOptional<EPropertyChangeType> ChangeResult =
+        FPropertyUIHelper::DisplayNumericDragN<uint32>(PropertyLabel, DataPtr, 1, Metadata);
     if (!ChangeResult.IsSet())
     {
         return;
@@ -289,16 +243,8 @@ void FUInt64Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel,
 {
     FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    const float DeltaSensitivity = Metadata.LinearDeltaSensitivity;
-    const char* ToolTip = Metadata.ToolTip.IsSet() ? **Metadata.ToolTip : nullptr;
-
-    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<uint64>(
-        PropertyLabel,
-        DataPtr, 1,
-        DeltaSensitivity,
-        nullptr,
-        ToolTip
-    );
+    const TOptional<EPropertyChangeType> ChangeResult =
+        FPropertyUIHelper::DisplayNumericDragN<uint64>(PropertyLabel, DataPtr, 1, Metadata);
     if (!ChangeResult.IsSet())
     {
         return;
@@ -312,16 +258,8 @@ void FFloatProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, 
 {
     FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    const float DeltaSensitivity = Metadata.LinearDeltaSensitivity;
-    const char* ToolTip = Metadata.ToolTip.IsSet() ? **Metadata.ToolTip : nullptr;
-
-    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(
-        PropertyLabel,
-        DataPtr, 1,
-        DeltaSensitivity,
-        nullptr,
-        ToolTip
-    );
+    const TOptional<EPropertyChangeType> ChangeResult =
+        FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 1, Metadata);
     if (!ChangeResult.IsSet())
     {
         return;
@@ -335,16 +273,8 @@ void FDoubleProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel,
 {
     FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    const float DeltaSensitivity = Metadata.LinearDeltaSensitivity;
-    const char* ToolTip = Metadata.ToolTip.IsSet() ? **Metadata.ToolTip : nullptr;
-
-    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<double>(
-        PropertyLabel,
-        DataPtr, 1,
-        DeltaSensitivity,
-        nullptr,
-        ToolTip
-    );
+    const TOptional<EPropertyChangeType> ChangeResult =
+        FPropertyUIHelper::DisplayNumericDragN<double>(PropertyLabel, DataPtr, 1, Metadata);
     if (!ChangeResult.IsSet())
     {
         return;
@@ -478,16 +408,8 @@ void FVector2DProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabe
 {
     FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    const float DeltaSensitivity = Metadata.LinearDeltaSensitivity;
-    const char* ToolTip = Metadata.ToolTip.IsSet() ? **Metadata.ToolTip : nullptr;
-
-    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(
-        PropertyLabel,
-        DataPtr, 2,
-        DeltaSensitivity,
-        nullptr,
-        ToolTip
-    );
+    const TOptional<EPropertyChangeType> ChangeResult =
+        FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 2, Metadata);
     if (!ChangeResult.IsSet())
     {
         return;
@@ -510,16 +432,8 @@ void FVectorProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel,
 {
     FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    const float DeltaSensitivity = Metadata.LinearDeltaSensitivity;
-    const char* ToolTip = Metadata.ToolTip.IsSet() ? **Metadata.ToolTip : nullptr;
-
-    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(
-        PropertyLabel,
-        DataPtr, 3,
-        DeltaSensitivity,
-        nullptr,
-        ToolTip
-    );
+    const TOptional<EPropertyChangeType> ChangeResult =
+        FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 3, Metadata);
     if (!ChangeResult.IsSet())
     {
         return;
@@ -542,16 +456,8 @@ void FVector4Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel
 {
     FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    const float DeltaSensitivity = Metadata.LinearDeltaSensitivity;
-    const char* ToolTip = Metadata.ToolTip.IsSet() ? **Metadata.ToolTip : nullptr;
-
-    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(
-        PropertyLabel,
-        DataPtr, 4,
-        DeltaSensitivity,
-        nullptr,
-        ToolTip
-    );
+    const TOptional<EPropertyChangeType> ChangeResult =
+        FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 4, Metadata);
     if (!ChangeResult.IsSet())
     {
         return;
@@ -574,16 +480,8 @@ void FRotatorProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel
 {
     FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    const float DeltaSensitivity = Metadata.LinearDeltaSensitivity;
-    const char* ToolTip = Metadata.ToolTip.IsSet() ? **Metadata.ToolTip : nullptr;
-
-    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(
-        PropertyLabel,
-        DataPtr, 3,
-        DeltaSensitivity,
-        nullptr,
-        ToolTip
-    );
+    const TOptional<EPropertyChangeType> ChangeResult =
+        FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 3, Metadata);
     if (!ChangeResult.IsSet())
     {
         return;
@@ -606,16 +504,8 @@ void FQuatProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, v
 {
     FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    const float DeltaSensitivity = Metadata.LinearDeltaSensitivity;
-    const char* ToolTip = Metadata.ToolTip.IsSet() ? **Metadata.ToolTip : nullptr;
-
-    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(
-        PropertyLabel,
-        DataPtr, 4,
-        DeltaSensitivity,
-        nullptr,
-        ToolTip
-    );
+    const TOptional<EPropertyChangeType> ChangeResult =
+        FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 4, Metadata);
     if (!ChangeResult.IsSet())
     {
         return;
@@ -643,9 +533,9 @@ void FTransformProperty::DisplayRawDataInImGui_Implement(const char* PropertyLab
             FRotator Rotation = Data->Rotator();
 
             bool bChangedThisFrame = false;
-            bChangedThisFrame |= FImGuiWidget::DrawVec3Control("Location", Data->Translation, 0.0f, 100.0f, Metadata.LinearDeltaSensitivity);
-            bChangedThisFrame |= FImGuiWidget::DrawRot3Control("Rotation", Rotation, 0.0f, 100.0f, Metadata.LinearDeltaSensitivity);
-            bChangedThisFrame |= FImGuiWidget::DrawVec3Control("Scale", Data->Scale3D, 1.0f, 100.0f, Metadata.LinearDeltaSensitivity);
+            bChangedThisFrame |= FImGuiWidget::DrawVec3Control("Location", Data->Translation, 0.0f, 100.0f, Metadata.DragDeltaSpeed);
+            bChangedThisFrame |= FImGuiWidget::DrawRot3Control("Rotation", Rotation, 0.0f, 100.0f, Metadata.DragDeltaSpeed);
+            bChangedThisFrame |= FImGuiWidget::DrawVec3Control("Scale", Data->Scale3D, 1.0f, 100.0f, Metadata.DragDeltaSpeed);
 
             if (bChangedThisFrame)
             {
@@ -684,9 +574,9 @@ void FMatrixProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel,
             FRotator Rotation = Transform.Rotator();
 
             bool bChanged = false;
-            bChanged |= FImGuiWidget::DrawVec3Control("Location", Transform.Translation, 0.0f, 100.0f, Metadata.LinearDeltaSensitivity);
-            bChanged |= FImGuiWidget::DrawRot3Control("Rotation", Rotation, 0.0f, 100.0f, Metadata.LinearDeltaSensitivity);
-            bChanged |= FImGuiWidget::DrawVec3Control("Scale", Transform.Scale3D, 1.0f, 100.0f, Metadata.LinearDeltaSensitivity);
+            bChanged |= FImGuiWidget::DrawVec3Control("Location", Transform.Translation, 0.0f, 100.0f, Metadata.DragDeltaSpeed);
+            bChanged |= FImGuiWidget::DrawRot3Control("Rotation", Rotation, 0.0f, 100.0f, Metadata.DragDeltaSpeed);
+            bChanged |= FImGuiWidget::DrawVec3Control("Scale", Transform.Scale3D, 1.0f, 100.0f, Metadata.DragDeltaSpeed);
 
             if (bChanged)
             {

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
@@ -637,9 +637,9 @@ void FTransformProperty::DisplayRawDataInImGui_Implement(const char* PropertyLab
             FRotator Rotation = Data->Rotator();
 
             bool bChangedThisFrame = false;
-            bChangedThisFrame |= FImGuiWidget::DrawVec3Control("Location", Data->Translation);
-            bChangedThisFrame |= FImGuiWidget::DrawRot3Control("Rotation", Rotation);
-            bChangedThisFrame |= FImGuiWidget::DrawVec3Control("Scale", Data->Scale3D, 1.0f);
+            bChangedThisFrame |= FImGuiWidget::DrawVec3Control("Location", Data->Translation, 0.0f, 100.0f, Metadata.LinearDeltaSensitivity);
+            bChangedThisFrame |= FImGuiWidget::DrawRot3Control("Rotation", Rotation, 0.0f, 100.0f, Metadata.LinearDeltaSensitivity);
+            bChangedThisFrame |= FImGuiWidget::DrawVec3Control("Scale", Data->Scale3D, 1.0f, 100.0f, Metadata.LinearDeltaSensitivity);
 
             if (bChangedThisFrame)
             {
@@ -678,9 +678,9 @@ void FMatrixProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel,
             FRotator Rotation = Transform.Rotator();
 
             bool bChanged = false;
-            bChanged |= FImGuiWidget::DrawVec3Control("Location", Transform.Translation);
-            bChanged |= FImGuiWidget::DrawRot3Control("Rotation", Rotation);
-            bChanged |= FImGuiWidget::DrawVec3Control("Scale", Transform.Scale3D, 1.0f);
+            bChanged |= FImGuiWidget::DrawVec3Control("Location", Transform.Translation, 0.0f, 100.0f, Metadata.LinearDeltaSensitivity);
+            bChanged |= FImGuiWidget::DrawRot3Control("Rotation", Rotation, 0.0f, 100.0f, Metadata.LinearDeltaSensitivity);
+            bChanged |= FImGuiWidget::DrawVec3Control("Scale", Transform.Scale3D, 1.0f, 100.0f, Metadata.LinearDeltaSensitivity);
 
             if (bChanged)
             {

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
@@ -744,19 +744,28 @@ void FColorProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, 
     FColor* Data = static_cast<FColor*>(DataPtr);
     FLinearColor LinearColorForUI = FLinearColor(*Data);
 
-    constexpr ImGuiColorEditFlags Flags =
-        ImGuiColorEditFlags_DisplayRGB
-        | ImGuiColorEditFlags_AlphaBar
-        | ImGuiColorEditFlags_AlphaPreview
-        | ImGuiColorEditFlags_AlphaPreviewHalf;
-
     ImGui::Text("%s", PropertyLabel);
     if (Metadata.ToolTip.IsSet())
     {
         ImGui::SetItemTooltip("%s", **Metadata.ToolTip);
     }
     ImGui::SameLine();
-    if (ImGui::ColorEdit4(std::format("##{}", PropertyLabel).c_str(), reinterpret_cast<float*>(&LinearColorForUI), Flags))
+
+    bool bChanged;
+    ImGuiColorEditFlags EditFlags = ImGuiColorEditFlags_DisplayRGB;
+    if (Metadata.HideAlphaChannel) // 알파 채널 숨김
+    {
+        bChanged = ImGui::ColorEdit3(std::format("##{}", PropertyLabel).c_str(), reinterpret_cast<float*>(&LinearColorForUI), EditFlags);
+    }
+    else
+    {
+        EditFlags |= ImGuiColorEditFlags_AlphaBar
+            | ImGuiColorEditFlags_AlphaPreview
+            | ImGuiColorEditFlags_AlphaPreviewHalf;
+        bChanged = ImGui::ColorEdit4(std::format("##{}", PropertyLabel).c_str(), reinterpret_cast<float*>(&LinearColorForUI), EditFlags);
+    }
+
+    if (bChanged)
     {
         *Data = LinearColorForUI.ToColorRawRGB8();
         if (OwnerObject)
@@ -765,7 +774,6 @@ void FColorProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, 
             OwnerObject->PostEditChangeProperty(Event);
         }
     }
-
 }
 
 void FLinearColorProperty::DisplayInImGui(UObject* Object) const
@@ -783,19 +791,28 @@ void FLinearColorProperty::DisplayRawDataInImGui_Implement(const char* PropertyL
 
     FLinearColor* Data = static_cast<FLinearColor*>(DataPtr);
 
-    constexpr ImGuiColorEditFlags Flags =
-        ImGuiColorEditFlags_Float
-        | ImGuiColorEditFlags_AlphaBar
-        | ImGuiColorEditFlags_AlphaPreview
-        | ImGuiColorEditFlags_AlphaPreviewHalf;
-
     ImGui::Text("%s", PropertyLabel);
     if (Metadata.ToolTip.IsSet())
     {
         ImGui::SetItemTooltip("%s", **Metadata.ToolTip);
     }
+
     ImGui::SameLine();
-    if (ImGui::ColorEdit4(std::format("##{}", PropertyLabel).c_str(), reinterpret_cast<float*>(Data), Flags))
+    bool bChanged;
+    ImGuiColorEditFlags EditFlags = ImGuiColorEditFlags_Float;
+    if (Metadata.HideAlphaChannel) // 알파 채널 숨김
+    {
+        bChanged = ImGui::ColorEdit3(std::format("##{}", PropertyLabel).c_str(), reinterpret_cast<float*>(Data), EditFlags);
+    }
+    else
+    {
+        EditFlags |= ImGuiColorEditFlags_AlphaBar
+            | ImGuiColorEditFlags_AlphaPreview
+            | ImGuiColorEditFlags_AlphaPreviewHalf;
+        bChanged = ImGui::ColorEdit4(std::format("##{}", PropertyLabel).c_str(), reinterpret_cast<float*>(Data), EditFlags);
+    }
+
+    if (bChanged)
     {
         if (OwnerObject)
         {

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
@@ -381,6 +381,12 @@ void FBoolProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, v
             OwnerObject->PostEditChangeProperty(Event);
         }
     }
+
+    // 다음에 오는 UI Inline으로 표시
+    if (Metadata.InlineEditConditionToggle)
+    {
+        ImGui::SameLine();
+    }
 }
 
 void FStrProperty::DisplayInImGui(UObject* Object) const

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
@@ -120,7 +120,10 @@ void FInt8Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel, v
     FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<int8>(PropertyLabel, DataPtr, 1);
-    if (!ChangeResult.IsSet()) return;
+    if (!ChangeResult.IsSet())
+    {
+        return;
+    }
 
     FPropertyChangedEvent Event{const_cast<FInt8Property*>(this), OwnerObject, *ChangeResult};
     OwnerObject->PostEditChangeProperty(Event);
@@ -131,7 +134,10 @@ void FInt16Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel, 
     FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<int16>(PropertyLabel, DataPtr, 1);
-    if (!ChangeResult.IsSet()) return;
+    if (!ChangeResult.IsSet())
+    {
+        return;
+    }
 
     FPropertyChangedEvent Event{const_cast<FInt16Property*>(this), OwnerObject, *ChangeResult};
     OwnerObject->PostEditChangeProperty(Event);
@@ -142,7 +148,10 @@ void FInt32Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel, 
     FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<int32>(PropertyLabel, DataPtr, 1);
-    if (!ChangeResult.IsSet()) return;
+    if (!ChangeResult.IsSet())
+    {
+        return;
+    }
 
     FPropertyChangedEvent Event{const_cast<FInt32Property*>(this), OwnerObject, *ChangeResult};
     OwnerObject->PostEditChangeProperty(Event);
@@ -153,7 +162,10 @@ void FInt64Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel, 
     FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<int64>(PropertyLabel, DataPtr, 1);
-    if (!ChangeResult.IsSet()) return;
+    if (!ChangeResult.IsSet())
+    {
+        return;
+    }
 
     FPropertyChangedEvent Event{const_cast<FInt64Property*>(this), OwnerObject, *ChangeResult};
     OwnerObject->PostEditChangeProperty(Event);
@@ -164,7 +176,10 @@ void FUInt8Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel, 
     FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<uint8>(PropertyLabel, DataPtr, 1);
-    if (!ChangeResult.IsSet()) return;
+    if (!ChangeResult.IsSet())
+    {
+        return;
+    }
 
     FPropertyChangedEvent Event{const_cast<FUInt8Property*>(this), OwnerObject, *ChangeResult};
     OwnerObject->PostEditChangeProperty(Event);
@@ -175,7 +190,10 @@ void FUInt16Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel,
     FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<uint16>(PropertyLabel, DataPtr, 1);
-    if (!ChangeResult.IsSet()) return;
+    if (!ChangeResult.IsSet())
+    {
+        return;
+    }
 
     FPropertyChangedEvent Event{const_cast<FUInt16Property*>(this), OwnerObject, *ChangeResult};
     OwnerObject->PostEditChangeProperty(Event);
@@ -186,7 +204,10 @@ void FUInt32Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel,
     FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<uint32>(PropertyLabel, DataPtr, 1);
-    if (!ChangeResult.IsSet()) return;
+    if (!ChangeResult.IsSet())
+    {
+        return;
+    }
 
     FPropertyChangedEvent Event{const_cast<FUInt32Property*>(this), OwnerObject, *ChangeResult};
     OwnerObject->PostEditChangeProperty(Event);
@@ -197,7 +218,10 @@ void FUInt64Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel,
     FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<uint64>(PropertyLabel, DataPtr, 1);
-    if (!ChangeResult.IsSet()) return;
+    if (!ChangeResult.IsSet())
+    {
+        return;
+    }
 
     FPropertyChangedEvent Event{const_cast<FUInt64Property*>(this), OwnerObject, *ChangeResult};
     OwnerObject->PostEditChangeProperty(Event);
@@ -208,7 +232,10 @@ void FFloatProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, 
     FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 1);
-    if (!ChangeResult.IsSet()) return;
+    if (!ChangeResult.IsSet())
+    {
+        return;
+    }
 
     FPropertyChangedEvent Event{const_cast<FFloatProperty*>(this), OwnerObject, *ChangeResult};
     OwnerObject->PostEditChangeProperty(Event);
@@ -219,7 +246,10 @@ void FDoubleProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel,
     FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<double>(PropertyLabel, DataPtr, 1);
-    if (!ChangeResult.IsSet()) return;
+    if (!ChangeResult.IsSet())
+    {
+        return;
+    }
 
     FPropertyChangedEvent Event{const_cast<FDoubleProperty*>(this), OwnerObject, *ChangeResult};
     OwnerObject->PostEditChangeProperty(Event);
@@ -328,7 +358,10 @@ void FVector2DProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabe
     FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 2);
-    if (!ChangeResult.IsSet()) return;
+    if (!ChangeResult.IsSet())
+    {
+        return;
+    }
 
     FPropertyChangedEvent Event{const_cast<FVector2DProperty*>(this), OwnerObject, *ChangeResult};
     OwnerObject->PostEditChangeProperty(Event);
@@ -348,7 +381,10 @@ void FVectorProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel,
     FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 3);
-    if (!ChangeResult.IsSet()) return;
+    if (!ChangeResult.IsSet())
+    {
+        return;
+    }
 
     FPropertyChangedEvent Event{const_cast<FVectorProperty*>(this), OwnerObject, *ChangeResult};
     OwnerObject->PostEditChangeProperty(Event);
@@ -368,7 +404,10 @@ void FVector4Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel
     FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 4);
-    if (!ChangeResult.IsSet()) return;
+    if (!ChangeResult.IsSet())
+    {
+        return;
+    }
 
     FPropertyChangedEvent Event{const_cast<FVector4Property*>(this), OwnerObject, *ChangeResult};
     OwnerObject->PostEditChangeProperty(Event);
@@ -388,7 +427,10 @@ void FRotatorProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel
     FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 3);
-    if (!ChangeResult.IsSet()) return;
+    if (!ChangeResult.IsSet())
+    {
+        return;
+    }
 
     FPropertyChangedEvent Event{const_cast<FRotatorProperty*>(this), OwnerObject, *ChangeResult};
     OwnerObject->PostEditChangeProperty(Event);
@@ -408,7 +450,10 @@ void FQuatProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, v
     FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
     const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 4);
-    if (!ChangeResult.IsSet()) return;
+    if (!ChangeResult.IsSet())
+    {
+        return;
+    }
 
     FPropertyChangedEvent Event{const_cast<FQuatProperty*>(this), OwnerObject, *ChangeResult};
     OwnerObject->PostEditChangeProperty(Event);

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
@@ -24,7 +24,12 @@ struct FPropertyUIHelper
 {
     template <NumericType NumType>
     static TOptional<EPropertyChangeType> DisplayNumericDragN(
-        const char* PropertyLabel, void* InData, int Components, float Speed = 1.0f, const char* Format = nullptr
+        const char* PropertyLabel,
+        void* InData,
+        int Components,
+        float Speed = 1.0f,
+        const char* Format = nullptr,
+        const char* ToolTip = nullptr
     )
     {
         NumType* Data = static_cast<NumType*>(InData);
@@ -45,6 +50,10 @@ struct FPropertyUIHelper
         else { static_assert(TAlwaysFalse<NumType>); }
 
         ImGui::Text("%s", PropertyLabel);
+        if (ToolTip)
+        {
+            ImGui::SetItemTooltip("%s", ToolTip);
+        }
         ImGui::SameLine();
         const std::string FormatStr = std::format("##{}", PropertyLabel);
         const bool bIsInteractive = ImGui::DragScalarN(FormatStr.c_str(), DataType, Data, Components, Speed, &Min, &Max, Format);
@@ -67,7 +76,7 @@ struct FPropertyUIHelper
 void FProperty::DisplayInImGui(UObject* Object) const
 {
     void* Data = GetPropertyData(Object);
-    DisplayRawDataInImGui(Name, Data, Object);
+    DisplayRawDataInImGui(*Metadata.DisplayName.Get(Name), Data, Object);
 }
 
 void FProperty::DisplayRawDataInImGui(const char* PropertyLabel, void* DataPtr, UObject* OwnerObject) const
@@ -119,7 +128,16 @@ void FInt8Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel, v
 {
     FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<int8>(PropertyLabel, DataPtr, 1);
+    const float DeltaSensitivity = Metadata.LinearDeltaSensitivity;
+    const char* ToolTip = Metadata.ToolTip.IsSet() ? **Metadata.ToolTip : nullptr;
+
+    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<int8>(
+        PropertyLabel,
+        DataPtr, 1,
+        DeltaSensitivity,
+        nullptr,
+        ToolTip
+    );
     if (!ChangeResult.IsSet())
     {
         return;
@@ -133,7 +151,16 @@ void FInt16Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel, 
 {
     FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<int16>(PropertyLabel, DataPtr, 1);
+    const float DeltaSensitivity = Metadata.LinearDeltaSensitivity;
+    const char* ToolTip = Metadata.ToolTip.IsSet() ? **Metadata.ToolTip : nullptr;
+
+    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<int16>(
+        PropertyLabel,
+        DataPtr, 1,
+        DeltaSensitivity,
+        nullptr,
+        ToolTip
+    );
     if (!ChangeResult.IsSet())
     {
         return;
@@ -147,7 +174,16 @@ void FInt32Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel, 
 {
     FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<int32>(PropertyLabel, DataPtr, 1);
+    const float DeltaSensitivity = Metadata.LinearDeltaSensitivity;
+    const char* ToolTip = Metadata.ToolTip.IsSet() ? **Metadata.ToolTip : nullptr;
+
+    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<int32>(
+        PropertyLabel,
+        DataPtr, 1,
+        DeltaSensitivity,
+        nullptr,
+        ToolTip
+    );
     if (!ChangeResult.IsSet())
     {
         return;
@@ -161,7 +197,16 @@ void FInt64Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel, 
 {
     FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<int64>(PropertyLabel, DataPtr, 1);
+    const float DeltaSensitivity = Metadata.LinearDeltaSensitivity;
+    const char* ToolTip = Metadata.ToolTip.IsSet() ? **Metadata.ToolTip : nullptr;
+
+    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<int64>(
+        PropertyLabel,
+        DataPtr, 1,
+        DeltaSensitivity,
+        nullptr,
+        ToolTip
+    );
     if (!ChangeResult.IsSet())
     {
         return;
@@ -175,7 +220,16 @@ void FUInt8Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel, 
 {
     FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<uint8>(PropertyLabel, DataPtr, 1);
+    const float DeltaSensitivity = Metadata.LinearDeltaSensitivity;
+    const char* ToolTip = Metadata.ToolTip.IsSet() ? **Metadata.ToolTip : nullptr;
+
+    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<uint8>(
+        PropertyLabel,
+        DataPtr, 1,
+        DeltaSensitivity,
+        nullptr,
+        ToolTip
+    );
     if (!ChangeResult.IsSet())
     {
         return;
@@ -189,7 +243,16 @@ void FUInt16Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel,
 {
     FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<uint16>(PropertyLabel, DataPtr, 1);
+    const float DeltaSensitivity = Metadata.LinearDeltaSensitivity;
+    const char* ToolTip = Metadata.ToolTip.IsSet() ? **Metadata.ToolTip : nullptr;
+
+    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<uint16>(
+        PropertyLabel,
+        DataPtr, 1,
+        DeltaSensitivity,
+        nullptr,
+        ToolTip
+    );
     if (!ChangeResult.IsSet())
     {
         return;
@@ -203,7 +266,16 @@ void FUInt32Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel,
 {
     FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<uint32>(PropertyLabel, DataPtr, 1);
+    const float DeltaSensitivity = Metadata.LinearDeltaSensitivity;
+    const char* ToolTip = Metadata.ToolTip.IsSet() ? **Metadata.ToolTip : nullptr;
+
+    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<uint32>(
+        PropertyLabel,
+        DataPtr, 1,
+        DeltaSensitivity,
+        nullptr,
+        ToolTip
+    );
     if (!ChangeResult.IsSet())
     {
         return;
@@ -217,7 +289,16 @@ void FUInt64Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel,
 {
     FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<uint64>(PropertyLabel, DataPtr, 1);
+    const float DeltaSensitivity = Metadata.LinearDeltaSensitivity;
+    const char* ToolTip = Metadata.ToolTip.IsSet() ? **Metadata.ToolTip : nullptr;
+
+    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<uint64>(
+        PropertyLabel,
+        DataPtr, 1,
+        DeltaSensitivity,
+        nullptr,
+        ToolTip
+    );
     if (!ChangeResult.IsSet())
     {
         return;
@@ -231,7 +312,16 @@ void FFloatProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, 
 {
     FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 1);
+    const float DeltaSensitivity = Metadata.LinearDeltaSensitivity;
+    const char* ToolTip = Metadata.ToolTip.IsSet() ? **Metadata.ToolTip : nullptr;
+
+    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(
+        PropertyLabel,
+        DataPtr, 1,
+        DeltaSensitivity,
+        nullptr,
+        ToolTip
+    );
     if (!ChangeResult.IsSet())
     {
         return;
@@ -245,7 +335,16 @@ void FDoubleProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel,
 {
     FNumericProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<double>(PropertyLabel, DataPtr, 1);
+    const float DeltaSensitivity = Metadata.LinearDeltaSensitivity;
+    const char* ToolTip = Metadata.ToolTip.IsSet() ? **Metadata.ToolTip : nullptr;
+
+    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<double>(
+        PropertyLabel,
+        DataPtr, 1,
+        DeltaSensitivity,
+        nullptr,
+        ToolTip
+    );
     if (!ChangeResult.IsSet())
     {
         return;
@@ -268,7 +367,13 @@ void FBoolProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, v
 {
     FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    if (ImGui::Checkbox(PropertyLabel, static_cast<bool*>(DataPtr)))
+    ImGui::Text("%s", PropertyLabel);
+    if (Metadata.ToolTip.IsSet())
+    {
+        ImGui::SetItemTooltip("%s", **Metadata.ToolTip);
+    }
+    ImGui::SameLine();
+    if (ImGui::Checkbox(std::format("##{}", PropertyLabel).c_str(), static_cast<bool*>(DataPtr)))
     {
         if (IsValid(OwnerObject))
         {
@@ -300,6 +405,11 @@ void FStrProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, vo
     bool bChanged = false;
 
     ImGui::Text("%s", PropertyLabel);
+    // 툴팁 표시
+    if (Metadata.ToolTip.IsSet())
+    {
+        ImGui::SetItemTooltip("%s", **Metadata.ToolTip);
+    }
     ImGui::SameLine();
     if (ImGui::InputText(std::format("##{}", PropertyLabel).c_str(), Buffer, IMGUI_FSTRING_BUFFER_SIZE, ImGuiInputTextFlags_EnterReturnsTrue))
     {
@@ -338,6 +448,11 @@ void FNameProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, v
     ImGui::BeginDisabled(true);
     {
         ImGui::Text("%s", PropertyLabel);
+        // 툴팁 표시
+        if (Metadata.ToolTip.IsSet())
+        {
+            ImGui::SetItemTooltip("%s", **Metadata.ToolTip);
+        }
         ImGui::SameLine();
         ImGui::InputText(std::format("##{}", PropertyLabel).c_str(), NameStr.data(), NameStr.size(), ImGuiInputTextFlags_ReadOnly);
     }
@@ -357,7 +472,16 @@ void FVector2DProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabe
 {
     FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 2);
+    const float DeltaSensitivity = Metadata.LinearDeltaSensitivity;
+    const char* ToolTip = Metadata.ToolTip.IsSet() ? **Metadata.ToolTip : nullptr;
+
+    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(
+        PropertyLabel,
+        DataPtr, 2,
+        DeltaSensitivity,
+        nullptr,
+        ToolTip
+    );
     if (!ChangeResult.IsSet())
     {
         return;
@@ -380,7 +504,16 @@ void FVectorProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel,
 {
     FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 3);
+    const float DeltaSensitivity = Metadata.LinearDeltaSensitivity;
+    const char* ToolTip = Metadata.ToolTip.IsSet() ? **Metadata.ToolTip : nullptr;
+
+    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(
+        PropertyLabel,
+        DataPtr, 3,
+        DeltaSensitivity,
+        nullptr,
+        ToolTip
+    );
     if (!ChangeResult.IsSet())
     {
         return;
@@ -403,7 +536,16 @@ void FVector4Property::DisplayRawDataInImGui_Implement(const char* PropertyLabel
 {
     FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 4);
+    const float DeltaSensitivity = Metadata.LinearDeltaSensitivity;
+    const char* ToolTip = Metadata.ToolTip.IsSet() ? **Metadata.ToolTip : nullptr;
+
+    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(
+        PropertyLabel,
+        DataPtr, 4,
+        DeltaSensitivity,
+        nullptr,
+        ToolTip
+    );
     if (!ChangeResult.IsSet())
     {
         return;
@@ -426,7 +568,16 @@ void FRotatorProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel
 {
     FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 3);
+    const float DeltaSensitivity = Metadata.LinearDeltaSensitivity;
+    const char* ToolTip = Metadata.ToolTip.IsSet() ? **Metadata.ToolTip : nullptr;
+
+    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(
+        PropertyLabel,
+        DataPtr, 3,
+        DeltaSensitivity,
+        nullptr,
+        ToolTip
+    );
     if (!ChangeResult.IsSet())
     {
         return;
@@ -449,7 +600,16 @@ void FQuatProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, v
 {
     FProperty::DisplayRawDataInImGui_Implement(PropertyLabel, DataPtr, OwnerObject);
 
-    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(PropertyLabel, DataPtr, 4);
+    const float DeltaSensitivity = Metadata.LinearDeltaSensitivity;
+    const char* ToolTip = Metadata.ToolTip.IsSet() ? **Metadata.ToolTip : nullptr;
+
+    const TOptional<EPropertyChangeType> ChangeResult = FPropertyUIHelper::DisplayNumericDragN<float>(
+        PropertyLabel,
+        DataPtr, 4,
+        DeltaSensitivity,
+        nullptr,
+        ToolTip
+    );
     if (!ChangeResult.IsSet())
     {
         return;
@@ -465,6 +625,12 @@ void FTransformProperty::DisplayRawDataInImGui_Implement(const char* PropertyLab
 
     if (ImGui::TreeNode(PropertyLabel))
     {
+        // 툴팁 표시
+        if (Metadata.ToolTip.IsSet())
+        {
+            ImGui::SetItemTooltip("%s", **Metadata.ToolTip);
+        }
+
         ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));
         {
             FTransform* Data = static_cast<FTransform*>(DataPtr);
@@ -499,6 +665,12 @@ void FMatrixProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel,
     if (ImGui::TreeNode(PropertyLabel))
     {
         FMatrix* Data = static_cast<FMatrix*>(DataPtr);
+
+        // 툴팁 표시
+        if (Metadata.ToolTip.IsSet())
+        {
+            ImGui::SetItemTooltip("%s", **Metadata.ToolTip);
+        }
 
         ImGui::BeginDisabled(HasAnyFlags(Flags, EPropertyFlags::VisibleAnywhere));
         {
@@ -573,6 +745,10 @@ void FColorProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel, 
         | ImGuiColorEditFlags_AlphaPreviewHalf;
 
     ImGui::Text("%s", PropertyLabel);
+    if (Metadata.ToolTip.IsSet())
+    {
+        ImGui::SetItemTooltip("%s", **Metadata.ToolTip);
+    }
     ImGui::SameLine();
     if (ImGui::ColorEdit4(std::format("##{}", PropertyLabel).c_str(), reinterpret_cast<float*>(&LinearColorForUI), Flags))
     {
@@ -608,6 +784,10 @@ void FLinearColorProperty::DisplayRawDataInImGui_Implement(const char* PropertyL
         | ImGuiColorEditFlags_AlphaPreviewHalf;
 
     ImGui::Text("%s", PropertyLabel);
+    if (Metadata.ToolTip.IsSet())
+    {
+        ImGui::SetItemTooltip("%s", **Metadata.ToolTip);
+    }
     ImGui::SameLine();
     if (ImGui::ColorEdit4(std::format("##{}", PropertyLabel).c_str(), reinterpret_cast<float*>(Data), Flags))
     {
@@ -645,6 +825,11 @@ void FSubclassOfProperty::DisplayRawDataInImGui_Implement(const char* PropertyLa
     bool bChanged = false;
     const std::string CurrentClassName = (*Data) ? (*Data)->GetName().ToAnsiString() : "None";
     ImGui::Text("%s", PropertyLabel);
+    // 툴팁 표시
+    if (Metadata.ToolTip.IsSet())
+    {
+        ImGui::SetItemTooltip("%s", **Metadata.ToolTip);
+    }
     ImGui::SameLine();
     if (ImGui::BeginCombo(std::format("##{}", PropertyLabel).c_str(), CurrentClassName.c_str()))
     {
@@ -689,6 +874,12 @@ void FObjectProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel,
     {
         UObject** Object = static_cast<UObject**>(DataPtr);
         const UClass* ObjectClass = IsValid(*Object) ? (*Object)->GetClass() : nullptr;
+
+        // 툴팁 표시
+        if (Metadata.ToolTip.IsSet())
+        {
+            ImGui::SetItemTooltip("%s", **Metadata.ToolTip);
+        }
 
         // 포인터가 가리키는 객체를 수정, 여기서는 UObject의 인스턴스
         if (HasAnyFlags(Flags, EPropertyFlags::EditAnywhere))
@@ -748,6 +939,12 @@ void FStructProperty::DisplayRawDataInImGui_Implement(const char* PropertyLabel,
     {
         if (ImGui::TreeNodeEx(PropertyLabel, ImGuiTreeNodeFlags_Framed | ImGuiTreeNodeFlags_DefaultOpen))
         {
+            // 툴팁 표시
+            if (Metadata.ToolTip.IsSet())
+            {
+                ImGui::SetItemTooltip("%s", **Metadata.ToolTip);
+            }
+
             const UStruct* ActualStruct = *StructType;
             DisplayMembersRecursive(ActualStruct, DataPtr, OwnerObject);
             ImGui::TreePop();

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyDisplay.cpp
@@ -61,8 +61,7 @@ struct FPropertyUIHelper
             FormatStr.c_str(),
             DataType,
             Data, Components,
-            // Metadata.DragDeltaSpeed,
-            1,
+            Metadata.DragDeltaSpeed,
             &ClampMin, &ClampMax,
             Format,
             ImGuiSliderFlags_AlwaysClamp

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyMetadata.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyMetadata.cpp
@@ -1,1 +1,0 @@
-﻿#include "PropertyMetadata.h"

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyMetadata.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyMetadata.cpp
@@ -1,0 +1,1 @@
+﻿#include "PropertyMetadata.h"

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyMetadata.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyMetadata.h
@@ -1,0 +1,68 @@
+﻿#pragma once
+#include "Container/String.h"
+#include "Misc/Optional.h"
+
+
+struct FPropertyMetadata
+{
+    // 카테고리
+    TOptional<FString> Category;
+
+    // 툴팁
+    TOptional<FString> ToolTip;
+
+    // UI에 실제로 보여지는 이름
+    TOptional<FString> DisplayName;
+
+    /* Ex
+     * UPROPERTY(EditAnywhere, Category = "Move")
+     * bool bCanMove = true; 
+     * UPROPERTY(EditAnywhere, Category = "Move", meta = (EditCondition = "bCanMove"))
+     * int MoveSpeed = 100;
+     * // 숨김 옵션
+     * UPROPERTY(EditAnywhere, Category = "Move", meta = (EditCondition = "bCanMove", EditConditionHides))
+     * int MoveSpeed = 100;
+     * // Enum
+     * UENUM(BlueprintType)
+     * enum class ETestType : uint8 { A_Type, B_Type };
+     * UPROPERTY(EditAnywhere, Category = "Move")
+     * ETestType TestType = ETestType::A_Type;
+     * UPROPERTY(EditAnywhere, Category = "Move", meta = (EditCondition = "TestType == ETestType::A_Type"))
+     * float A_Speed = 10.0f;
+     * UPROPERTY(EditAnywhere, Category = "Move", meta = (EditCondition = "TestType == ETestType::B_Type"))
+     * float B_Speed = 1.0f;
+     */
+    // 특정 Property의 값에 따라서 프로퍼티의 에디터 노출 및 편집 가능 여부를 제어
+    // TOptional<?> EditCondition;
+
+    // DisplayAfter / DisplayPriority: 에디터에서 표시 순서 제어
+
+    // ArrayClamp 정수형 프로퍼티, 최대 Idx 제한
+
+    // bool Type에 대해서 UI상에 ImGui::SameLine을 적용할지 여부
+    bool InlineEditConditionToggle = false;
+
+    // +/- 의 증감 단위
+    // TOptional<float> Delta;
+
+    // ImGui::DragScalar의 마우스 감도
+    float LinearDeltaSensitivity = 1.0f;
+
+    // 실제 슬라이더의 값을 설정할 수 있는 최소치, (None이면 실제 타입의 Min)
+    TOptional<float> ClampMin;
+
+    // 실제 슬라이더의 값을 설정할 수 있는 최대치, (None이면 실제 타입의 Max)
+    TOptional<float> ClampMax;
+
+    // UI상에서 마우스로 값을 조절할 수 있는 최소치, (None이면 실제 타입의 Min)
+    TOptional<float> UIMin;
+
+    // UI상에서 마우스로 값을 조절할 수 있는 최대치, (None이면 실제 타입의 Max)
+    TOptional<float> UIMax;
+
+    // FColor, FLinearColor 등에서 알파 채널 숨김
+    bool HideAlphaChannel = false;
+
+public:
+    FPropertyMetadata() = default;
+};

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyMetadata.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyMetadata.h
@@ -6,7 +6,7 @@
 struct FPropertyMetadata
 {
     // 카테고리
-    TOptional<FString> Category = {};
+    // TOptional<FString> Category = {}; // TODO: 카테고리 만들기
 
     // UI에 실제로 보여지는 이름
     TOptional<FString> DisplayName = {};

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyMetadata.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyMetadata.h
@@ -45,8 +45,8 @@ struct FPropertyMetadata
     // +/- 의 증감 단위
     // TOptional<float> Delta;
 
-    // ImGui::DragScalar의 마우스 감도
-    float LinearDeltaSensitivity = 1.0f;
+    // ImGui::DragScalar의 속도
+    float DragDeltaSpeed = 0.1f;
 
     // 실제 슬라이더의 값을 설정할 수 있는 최소치, (None이면 실제 타입의 Min)
     TOptional<float> ClampMin = {};

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyMetadata.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyMetadata.h
@@ -54,11 +54,11 @@ struct FPropertyMetadata
     // 실제 슬라이더의 값을 설정할 수 있는 최대치, (None이면 실제 타입의 Max)
     TOptional<float> ClampMax = {};
 
-    // UI상에서 마우스로 값을 조절할 수 있는 최소치, (None이면 실제 타입의 Min)
-    TOptional<float> UIMin = {};
-
-    // UI상에서 마우스로 값을 조절할 수 있는 최대치, (None이면 실제 타입의 Max)
-    TOptional<float> UIMax = {};
+    // // UI상에서 마우스로 값을 조절할 수 있는 최소치, (None이면 실제 타입의 Min)
+    // TOptional<float> UIMin = {};
+    //
+    // // UI상에서 마우스로 값을 조절할 수 있는 최대치, (None이면 실제 타입의 Max)
+    // TOptional<float> UIMax = {};
 
     // FColor, FLinearColor 등에서 알파 채널 숨김
     bool HideAlphaChannel = false;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyMetadata.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyMetadata.h
@@ -8,11 +8,11 @@ struct FPropertyMetadata
     // 카테고리
     TOptional<FString> Category = {};
 
-    // 툴팁
-    TOptional<FString> ToolTip = {};
-
     // UI에 실제로 보여지는 이름
     TOptional<FString> DisplayName = {};
+
+    // 툴팁
+    TOptional<FString> ToolTip = {};
 
     /* Ex
      * UPROPERTY(EditAnywhere, Category = "Move")

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyMetadata.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyMetadata.h
@@ -6,13 +6,13 @@
 struct FPropertyMetadata
 {
     // 카테고리
-    TOptional<FString> Category;
+    TOptional<FString> Category = {};
 
     // 툴팁
-    TOptional<FString> ToolTip;
+    TOptional<FString> ToolTip = {};
 
     // UI에 실제로 보여지는 이름
-    TOptional<FString> DisplayName;
+    TOptional<FString> DisplayName = {};
 
     /* Ex
      * UPROPERTY(EditAnywhere, Category = "Move")
@@ -33,7 +33,7 @@ struct FPropertyMetadata
      * float B_Speed = 1.0f;
      */
     // 특정 Property의 값에 따라서 프로퍼티의 에디터 노출 및 편집 가능 여부를 제어
-    // TOptional<?> EditCondition;
+    // TOptional<?> EditCondition = {};
 
     // DisplayAfter / DisplayPriority: 에디터에서 표시 순서 제어
 
@@ -49,20 +49,17 @@ struct FPropertyMetadata
     float LinearDeltaSensitivity = 1.0f;
 
     // 실제 슬라이더의 값을 설정할 수 있는 최소치, (None이면 실제 타입의 Min)
-    TOptional<float> ClampMin;
+    TOptional<float> ClampMin = {};
 
     // 실제 슬라이더의 값을 설정할 수 있는 최대치, (None이면 실제 타입의 Max)
-    TOptional<float> ClampMax;
+    TOptional<float> ClampMax = {};
 
     // UI상에서 마우스로 값을 조절할 수 있는 최소치, (None이면 실제 타입의 Min)
-    TOptional<float> UIMin;
+    TOptional<float> UIMin = {};
 
     // UI상에서 마우스로 값을 조절할 수 있는 최대치, (None이면 실제 타입의 Max)
-    TOptional<float> UIMax;
+    TOptional<float> UIMax = {};
 
     // FColor, FLinearColor 등에서 알파 채널 숨김
     bool HideAlphaChannel = false;
-
-public:
-    FPropertyMetadata() = default;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyTypes.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/PropertyTypes.h
@@ -147,11 +147,12 @@ enum EPropertyFlags : uint32  // NOLINT(performance-enum-size)
     VisibleAnywhere    = 1 << 0,  // ImGui에서 읽기 전용으로 표시
     EditAnywhere       = 1 << 1,  // ImGui에서 읽기/쓰기 가능
     EditInline         = 1 << 2,  // ImGui에서 Edit과 동시에 Inline으로 Object의 Property까지 표시
-    LuaReadOnly        = 1 << 3,  // Lua에 읽기 전용으로 바인딩
-    LuaReadWrite       = 1 << 4,  // Lua에 읽기/쓰기로 바인딩
-    BitField           = 1 << 5,  // BitField인 경우
-    Transient          = 1 << 6,  // 휘발성 변수인 경우 (이 값은 저장이 안됨)
-    DuplicateTransient = 1 << 7,  // Duplicate할 때 기본값으로 복제
+    EditFixedSize      = 1 << 3,  // ImGui에서 동적 배열의 길이를 바꾸지 못하도록 변경 (Add/Delete 불가)
+    LuaReadOnly        = 1 << 4,  // Lua에 읽기 전용으로 바인딩
+    LuaReadWrite       = 1 << 5,  // Lua에 읽기/쓰기로 바인딩
+    BitField           = 1 << 6,  // BitField인 경우
+    Transient          = 1 << 7,  // 휘발성 변수인 경우 (이 값은 저장이 안됨)
+    DuplicateTransient = 1 << 8,  // Duplicate할 때 기본값으로 복제
     // ... 필요한 다른 플래그들 (예: SaveGame, Replicated 등)
 };
 

--- a/EngineSIU/EngineSIU/EngineSIU.vcxproj
+++ b/EngineSIU/EngineSIU/EngineSIU.vcxproj
@@ -238,6 +238,7 @@ xcopy /y /d "$(SolutionDir)$(ProjectName)\Engine\Source\ThirdParty\FBX\lib\x64\$
     <ClCompile Include="Engine\Source\Runtime\CoreUObject\UObject\ObjectUtils.cpp" />
     <ClCompile Include="Engine\Source\Runtime\CoreUObject\UObject\Property.cpp" />
     <ClCompile Include="Engine\Source\Runtime\CoreUObject\UObject\PropertyDisplay.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\CoreUObject\UObject\PropertyMetadata.cpp" />
     <ClCompile Include="Engine\Source\Runtime\CoreUObject\UObject\ScriptStruct.cpp" />
     <ClCompile Include="Engine\Source\Runtime\CoreUObject\UObject\Struct.cpp" />
     <ClCompile Include="Engine\Source\Runtime\CoreUObject\UObject\UObjectArray.cpp" />
@@ -537,6 +538,7 @@ xcopy /y /d "$(SolutionDir)$(ProjectName)\Engine\Source\ThirdParty\FBX\lib\x64\$
     <ClInclude Include="Engine\Source\Runtime\CoreUObject\UObject\ObjectTypes.h" />
     <ClInclude Include="Engine\Source\Runtime\CoreUObject\UObject\ObjectUtils.h" />
     <ClInclude Include="Engine\Source\Runtime\CoreUObject\UObject\Property.h" />
+    <ClInclude Include="Engine\Source\Runtime\CoreUObject\UObject\PropertyMetadata.h" />
     <ClInclude Include="Engine\Source\Runtime\CoreUObject\UObject\PropertyTypes.h" />
     <ClInclude Include="Engine\Source\Runtime\CoreUObject\UObject\ScriptStruct.h" />
     <ClInclude Include="Engine\Source\Runtime\CoreUObject\UObject\Struct.h" />

--- a/EngineSIU/EngineSIU/EngineSIU.vcxproj
+++ b/EngineSIU/EngineSIU/EngineSIU.vcxproj
@@ -238,7 +238,6 @@ xcopy /y /d "$(SolutionDir)$(ProjectName)\Engine\Source\ThirdParty\FBX\lib\x64\$
     <ClCompile Include="Engine\Source\Runtime\CoreUObject\UObject\ObjectUtils.cpp" />
     <ClCompile Include="Engine\Source\Runtime\CoreUObject\UObject\Property.cpp" />
     <ClCompile Include="Engine\Source\Runtime\CoreUObject\UObject\PropertyDisplay.cpp" />
-    <ClCompile Include="Engine\Source\Runtime\CoreUObject\UObject\PropertyMetadata.cpp" />
     <ClCompile Include="Engine\Source\Runtime\CoreUObject\UObject\ScriptStruct.cpp" />
     <ClCompile Include="Engine\Source\Runtime\CoreUObject\UObject\Struct.cpp" />
     <ClCompile Include="Engine\Source\Runtime\CoreUObject\UObject\UObjectArray.cpp" />


### PR DESCRIPTION
## 주요 변경사항

- 다양한 UI 헬퍼 함수에 메타데이터 파라미터를 추가하여 동적 처리가 가능하도록 개선했습니다.
- `ImGui DragScalar` 설정에서 변수명과 값의 의미를 더 명확하게 개선했습니다.
- 알파 채널 표시 옵션을 동적으로 처리하는 기능을 향상시켰습니다.
- ImGui에 툴팁 표시 기능과 추가적인 드래그 민감도(Drag sensitivity) 파라미터를 확장 추가했습니다.
- `UPROPERTY` 매크로의 메타데이터와 `DisplayName` 예시 지원을 추가했습니다.
- `PropertyMetadata` 구조체와 관련 로직을 도입했습니다.
- `FProperty` 및 그 하위 클래스의 생성자를 메타데이터 처리를 위해 리팩터링했습니다.
- 사용하지 않는 파일을 정리하고, 코드 가독성을 높이기 위해 주석 위치를 조정했습니다.

## 아직 지원하지 않는 기능
- Category 분류 기능은 아직 구현되지 않았습니다.
- FTransform, FMatrix에 대해서는 Clamp와 DeltaSpeed가 구현되어 있지 않아, 동작하지 않습니다.

## 개선할 내용
- 추후에 한번 FProperty의 파생 클래스를 정리해야 합니다.

## 사용 방법
```cpp
    UPROPERTY(
        EditAnywhere, { .DisplayName = "hello" },
        FVector, Velocity, = FVector::ZeroVector;
    )

    UPROPERTY(
        EditAnywhere, ({ .DisplayName = "My u8", .ToolTip = "wa u8" }),
        uint8, u8, = 0;
    )

    UPROPERTY(
        EditAnywhere, { .ToolTip = "wa 123" },
        uint8, gudtldn, = 0;
    )

    UPROPERTY(
        EditAnywhere, ({ .ToolTip = "hide alpha", .HideAlphaChannel = true }),
        FColor, color, = FColor::Blue;
    )

    UPROPERTY(
        EditAnywhere, ({ .ToolTip = "hide alpha linear", .HideAlphaChannel = true }),
        FLinearColor, lcolor, = FLinearColor::Black;
    )

    UPROPERTY(
        EditAnywhere, ({ .ToolTip = "DragDeltaSpeed 123", .DragDeltaSpeed = 123, .ClampMin = 20.0f, .ClampMax = 200.0f }),
        uint32, u32, = 0;
    )

    UPROPERTY(
        EditAnywhere, ({ .ToolTip = "DragDeltaSpeed 0.123f", .DragDeltaSpeed = 0.123f }),
        float, f32, = 0;
    )

    UPROPERTY(
        EditAnywhere, ({ .ToolTip = "DragDeltaSpeed 0.123f", .InlineEditConditionToggle = true }),
        bool, my_bool, = false;
    )

    UPROPERTY(
        EditAnywhere, { .ToolTip = "Inline String" },
        FString, InlineString,;
    )
```